### PR TITLE
changed set_as_index to False as default for add_ids()

### DIFF
--- a/src/eda_toolkit/main.py
+++ b/src/eda_toolkit/main.py
@@ -34,7 +34,7 @@ def add_ids(
     id_colname="ID",
     num_digits=9,
     seed=None,
-    set_as_index=True,
+    set_as_index=False,
 ):
     """
     Add a column of unique IDs with a specified number of digits to the dataframe.


### PR DESCRIPTION
**Changes Introduced**

1. Parameter Customization:
   - Updated parameter `set_as_index` to allow users to choose whether to set the new ID column as the index. Defaults to `False`.