### PR TITLE
updated default figsize to (10,10) in flex_corr_matrix

### DIFF
--- a/src/eda_toolkit/main.py
+++ b/src/eda_toolkit/main.py
@@ -2201,7 +2201,7 @@ def flex_corr_matrix(
     save_plots=False,
     image_path_png=None,
     image_path_svg=None,
-    figsize=(20, 20),
+    figsize=(10, 10),
     title="Cervical Cancer Data: Correlation Matrix",
     title_fontsize=16,
     label_fontsize=10,


### PR DESCRIPTION
### Update to Default `figsize` Parameter

Set the default `figsize` in`flex_corr_matrix()` to a more moderate size like `(10, 10)`. It makes the function more user-friendly by avoiding large, unwieldy plots by default, especially for smaller datasets or screens. Users who need a larger figure can still easily adjust the `figsize` parameter when they call the function.

### Benefits:

- **Better Default Experience**: A `(10, 10)` size is more manageable for most users and fits better on most screens without overwhelming the display.
- **Flexibility**: Since users can still pass their preferred `figsize` if needed, this change doesn't restrict customization.
