### PR TITLE
Make file_prefix optional with auto-generated default

### DIFF
--- a/src/eda_toolkit/main.py
+++ b/src/eda_toolkit/main.py
@@ -1257,9 +1257,7 @@ def stacked_crosstab_plot(
     # Generate plots if output is "both" or "plots_only"
     if output in ["both", "plots_only"]:
         if file_prefix is None:
-            raise ValueError(
-                "file_prefix must be provided when output " "includes plots"
-            )
+            file_prefix = f"{col}_{'_'.join(func_col)}"
 
         # Set default values for x, y, and p if not provided
         if x is None:


### PR DESCRIPTION
### **Title:** Make `file_prefix` Optional with Auto-Generated Default

**Description:**

This PR enhances the `stacked_crosstab_plot` function by making the `file_prefix` argument optional. If `file_prefix` is not provided by the user, the function will automatically generate a default prefix using the column names provided in the `col` and `func_col` parameters.

**Key Changes:**
- Removed the requirement to explicitly provide `file_prefix` when generating plots

**Original Code:**
```python
if file_prefix is None:
    raise ValueError(
        "file_prefix must be provided when output includes plots"
    )
```
- Added logic to automatically create a default `file_prefix` based on the column names, ensuring meaningful filenames for saved plots.

**Why This Change is Needed:**
Previously, the function required users to provide a `file_prefix` when output included plots, which could be cumbersome. This update streamlines the function, allowing users to omit `file_prefix` and still have plots saved with appropriate filenames.

**Updated Code:**
The above was replaced with a conditional check that automatically generates a default `file_prefix` if none is provided

```python
if file_prefix is None:
    file_prefix = f"{col}_{'_'.join(func_col)}"
```

**Testing:**
- Verified that plots are saved correctly with the auto-generated `file_prefix` when none is provided.
- Confirmed backward compatibility with existing functionality when `file_prefix` is explicitly specified.

**Impact:**
- Improves usability by reducing the number of required arguments for plot generation.
- Maintains functionality for users who wish to specify a custom `file_prefix`.

---

Please review the changes and provide feedback or approval as appropriate. Thank you!
