### PR TITLE
updated saving logic to ensure saving in stacked_crosstab_plot()

### DIFF
--- a/src/eda_toolkit/main.py
+++ b/src/eda_toolkit/main.py
@@ -1283,19 +1283,19 @@ def stacked_crosstab_plot(
 
         # Loop through each condition and create the plots
         for truth, legend, tit in zip(func_col, legend_labels_list, title):
-            if image_path_png and image_path_svg:
+            image_path = {}
+
+            if image_path_png:
                 func_col_filename_png = os.path.join(
                     image_path_png, f"{file_prefix}_{truth}.png"
                 )
+                image_path["png"] = func_col_filename_png
+
+            if image_path_svg:
                 func_col_filename_svg = os.path.join(
                     image_path_svg, f"{file_prefix}_{truth}.svg"
                 )
-                image_path = {
-                    "png": func_col_filename_png,
-                    "svg": func_col_filename_svg,
-                }
-            else:
-                image_path = {}
+                image_path["svg"] = func_col_filename_svg
 
             # Verify the DataFrame state before creating plots
             fig, axes = plt.subplots(nrows=nrows, ncols=1, figsize=(x, y))
@@ -1458,11 +1458,37 @@ def stacked_crosstab_plot(
                         ax1.legend().remove()
 
             fig.align_ylabels()
+
+            # Ensure save_formats is a list even if a string or tuple is passed
+            if isinstance(save_formats, str):
+                save_formats = [save_formats]
+            elif isinstance(save_formats, tuple):
+                save_formats = list(save_formats)
+
+            # Check for invalid save formats
+            valid_formats = []
+            if image_path_png:
+                valid_formats.append("png")
+            if image_path_svg:
+                valid_formats.append("svg")
+
+            # Throw an error if an invalid format is specified
+            for save_format in save_formats:
+                if save_format not in valid_formats:
+                    missing_path = f"image_path_{save_format}"
+                    raise ValueError(
+                        f"Invalid save format '{save_format}'. To save in this "
+                        f"format, you must first pass input for '{missing_path}'. "
+                        f"Valid options are: {valid_formats}"
+                    )
+
             if save_formats and isinstance(image_path, dict):
                 for save_format in save_formats:
                     if save_format in image_path:
                         full_path = image_path[save_format]
                         plt.savefig(full_path, bbox_inches="tight")
+                        print(f"Plot saved as {full_path}")
+
             plt.show()
             plt.close(fig)  # Ensure plot is closed after showing
 


### PR DESCRIPTION
### **PR Title**: Enhance Flexibility and Error Handling for Plot Saving in `stacked_crosstab_plot` Function

### **Description**:
This PR introduces several updates to the `stacked_crosstab_plot` function to improve flexibility in saving plots and enhance error handling. These changes ensure that users can specify various formats and paths more intuitively, and that clear errors are raised when necessary.

### **Changes Made**:

1. **Flexible `save_formats` Input**:
   - The `save_formats` parameter now accepts a single string, a tuple, or a list. This allows users to specify formats like `"png"`, `("png", "svg")`, or `["png", "svg"]` without needing to wrap single formats in a list.
   - If `save_formats` is provided as a string or tuple, it is automatically converted into a list for consistent processing.

2. **Dynamic Error Handling for Missing Paths**:
   - Added dynamic error handling that checks if the specified `save_format` corresponds to a provided path (`image_path_png` or `image_path_svg`).
   - If a format is specified in `save_formats` without a corresponding path, the function raises a `ValueError` indicating the missing path. The error message is dynamically generated based on the format (e.g., `"To save in this format, you must first pass input for 'image_path_png'."`).

3. **Enhanced Code Logic for Plot Saving**:
   - The logic that checks if paths are provided and handles the saving of plots was updated to be more intuitive. The function now correctly handles cases where only one of `image_path_png` or `image_path_svg` is provided.
   - The function no longer forces the user to provide both `image_path_png` and `image_path_svg` to save plots. It can now handle saving in one format without requiring the other.

```python
# Ensure save_formats is a list even if a string or tuple is passed
if isinstance(save_formats, str):
    save_formats = [save_formats]
elif isinstance(save_formats, tuple):
    save_formats = list(save_formats)

# Define valid formats based on provided image paths
valid_formats = []
if image_path_png:
    valid_formats.append("png")
if image_path_svg:
    valid_formats.append("svg")

# Throw an error if an invalid format is specified
for save_format in save_formats:
    if save_format not in valid_formats:
        missing_path = f"image_path_{save_format}"
        raise ValueError(
            f"Invalid save format '{save_format}'. To save in this format, "
            f"you must first pass input for '{missing_path}'. Valid options are: {valid_formats}"
        )

# Saving logic
if save_formats and isinstance(image_path, dict):
    for save_format in save_formats:
        if save_format in image_path:
            full_path = image_path[save_format]
            plt.savefig(full_path, bbox_inches="tight")
            print(f"Plot saved as {full_path}")
