### PR TITLE
Fix TypeError in stacked_crosstab_plot for save_formats

### DIFF
--- a/src/eda_toolkit/main.py
+++ b/src/eda_toolkit/main.py
@@ -1536,9 +1536,10 @@ def stacked_crosstab_plot(
     image_path_svg : str, optional
         Directory path where generated SVG plot images will be saved.
 
-    save_formats : list of str, optional
+    save_formats : list of str, optional (default=None)
         List of file formats to save the plot images in. Valid formats are
-        'png' and 'svg'.
+        'png' and 'svg'. If not provided, defaults to an empty list and no
+        images will be saved.
 
     color : list of str, optional
         List of colors to use for the plots. If not provided, a default

--- a/src/eda_toolkit/main.py
+++ b/src/eda_toolkit/main.py
@@ -1641,6 +1641,15 @@ def stacked_crosstab_plot(
             f"Invalid plot type: {plot_type}. Valid options are {valid_plot_types}"
         )
 
+    # Ensure save_formats is a list even if None, string, or tuple is passed
+    save_formats = (
+        save_formats or []
+    )  # Modified line: Ensures save_formats is an empty list if None
+    if isinstance(save_formats, str):
+        save_formats = [save_formats]
+    elif isinstance(save_formats, tuple):
+        save_formats = list(save_formats)
+
     # Initialize the dictionary to store crosstabs
     crosstabs_dict = {}
     # Default color settings


### PR DESCRIPTION
### Title: 
Fix TypeError in `stacked_crosstab_plot` for `save_formats`

### Description:
This PR addresses a `TypeError` in the `stacked_crosstab_plot` function when `save_formats` is `None`. The update ensures that `save_formats` defaults to an empty list, preventing iteration over a `NoneType` object.

### Changes:
- Initialize `save_formats` as an empty list if not provided.
- Add handling for string and tuple input types for `save_formats`.

### Issue Fixed:
Resolves `TypeError` when `save_formats` is `None`.
