### PR TITLE
ecdf integration into data_doctor and example script

### DIFF
--- a/py_example_scripts/ecdf_plot_integration_in_data_doctor.py
+++ b/py_example_scripts/ecdf_plot_integration_in_data_doctor.py
@@ -1,0 +1,38 @@
+# %%
+################################################################################
+##################### ECDF Plot Integration in data_doctor #####################
+################################################################################
+
+from ucimlrepo import fetch_ucirepo
+from eda_toolkit import data_doctor
+
+# %%
+################################################################################
+## UCI ML Repository
+################################################################################
+
+# fetch dataset
+adult = fetch_ucirepo(id=2)
+
+# data (as pandas dataframes)
+X = adult.data.features
+y = adult.data.targets
+
+# Combine X and y into entire df
+adult_df = X.join(y, how="inner")
+
+# %%
+################################################################################
+## data_doctor with ECDF
+################################################################################
+
+print("\nRunning data_doctor with plot_type=['kde', 'ecdf', 'box_violin'] ...\n")
+
+data_doctor(
+    df=adult_df,
+    feature_name="age",
+    plot_type=["kde", "ecdf", "box_violin"],
+    scale_conversion="log",
+)
+
+


### PR DESCRIPTION
# Add ECDF plot support to `data_doctor` (SciPy-free)

## Overview

This PR adds **ECDF (Empirical Cumulative Distribution Function)** support to the `data_doctor` function via a new `plot_type="ecdf"` option. The ECDF complements existing distribution plots (KDE, Histogram, and box/violin) by providing a cumulative, bin-free view of the data during exploratory analysis.

This enhancement was motivated by practitioner feedback and discussion at **JupyterCon 2025**, where there was interest in clearer, assumption-light distribution diagnostics.

---

## What’s Included

### Updated
- `eda_toolkit/plots.py`
  - Integrated ECDF plotting into `data_doctor`
  - Added `"ecdf"` as a supported `plot_type`
  - ECDF works alongside existing plot combinations (e.g. KDE + ECDF + boxplot)
  - Normal reference curve implemented using `math.erf` (no SciPy dependencies)

### Added
- `py_example_scripts/ecdf_plot_integration_in_data_doctor.py`
  - Standalone example demonstrating ECDF usage with `data_doctor`

No changes were made to package dependencies.

---

## Why ECDFs

ECDFs show **how much of the data has accumulated up to each value**, rather than how many observations fall into bins.

They are especially useful for:
- Understanding cumulative behavior
- Identifying skew and asymmetry
- Spotting cutoff effects or clustering
- Diagnosing where parametric assumptions (e.g. normality) break down

Unlike histograms or KDEs, ECDFs display every observation explicitly.

---

## Example Usage

```python
data_doctor(
    df=df,
    feature_name="age",
    plot_type=["kde", "ecdf", "box_violin"],
    scale_conversion="log",
)
```

---

In this combination:
- KDE shows overall shape
- ECDF highlights cumulative structure and deviations from a normal reference
- Box/Violin summarizes spread, central tendency, and outliers
<img width="1936" height="822" alt="image" src="https://github.com/user-attachments/assets/fd36d5e5-dc20-4a9c-b931-5e2d9168e374" />


## Summary

This PR:
- Adds "ecdf" as a new plot type in data_doctor
- Implements ECDF and normal reference curves without introducing SciPy
- Includes a concrete example script for users
- Expands eda_toolkit’s EDA capabilities with transparent, assumption-light diagnostics