### PR TITLE
fix(table1): handle NaN categories in groupby

### DIFF
--- a/py_example_notebooks/adult_income_data_management.ipynb
+++ b/py_example_notebooks/adult_income_data_management.ipynb
@@ -683,12 +683,12 @@
     "table1 = generate_table1(\n",
     "    df=df,\n",
     "    value_counts=True,\n",
-    "    max_categories=3,\n",
+    "    # max_categories=3,\n",
     "    export_markdown=True,\n",
     "    markdown_path=os.path.join(data_output, \"table1_summary.md\"),\n",
     ")\n",
     "\n",
-    "table1 = table1.drop(columns=[\"Type\", \"Mode\"])"
+    "# table1 = table1.drop(columns=[\"Type\", \"Mode\"])"
    ]
   },
   {
@@ -1386,7 +1386,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv_eda_3_8",
+   "display_name": "eda_venv (3.12.12)",
    "language": "python",
    "name": "python3"
   },
@@ -1400,7 +1400,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/py_example_scripts/table1_nans.py
+++ b/py_example_scripts/table1_nans.py
@@ -1,0 +1,24 @@
+import numpy as np
+import pandas as pd
+from eda_toolkit import generate_table1
+
+print("NaN mixed with valid categories:")
+# NaN mixed with valid categories
+df1 = pd.DataFrame({
+    "x":     ["a", "a", "a", "b", "b", "b", np.nan, np.nan, np.nan, np.nan],
+    "group": ["A", "B", "A", "B", "A", "B", "A",    "B",    "A",    "B"],
+})
+print(generate_table1(df1, categorical_cols=["x"], continuous_cols=[],
+                      groupby_col="group", value_counts=True))
+
+print()
+print("All-NaN column:")
+# All-NaN column
+df2 = pd.DataFrame({
+    "x":     [np.nan]*6,
+    "group": ["A", "B", "A", "B", "A", "B"],
+})
+print(generate_table1(df2, categorical_cols=["x"], continuous_cols=[],
+                      groupby_col="group", value_counts=True))
+
+

--- a/src/eda_toolkit/data_manager.py
+++ b/src/eda_toolkit/data_manager.py
@@ -1109,6 +1109,20 @@ def generate_table1(
             mode_val = series.mode().iloc[0] if not series.mode().empty else ""
 
             if groupby_col:
+                if series.dropna().empty:
+                    summary_row = {
+                        "Variable": col, "Type": "Categorical",
+                        "Mean": "", "SD": "", "Median": "", "Min": "", "Max": "",
+                        "Mode": mode_val,
+                        "Missing (n)": missing_n, "Missing (%)": missing_pct,
+                        "Count": 0, "Proportion (%)": 0,
+                        group1_label: "0 (0.00%)",
+                        group2_label: "0 (0.00%)",
+                        "P-value": "",
+                    }
+                    categorical_parts.append(summary_row)
+                    continue
+
                 ct = pd.crosstab(df[col], df[groupby_col])
                 ## warn instead of silently dropping non-2-column tables
                 if ct.shape[1] != 2:
@@ -1192,8 +1206,12 @@ def generate_table1(
                         else f"{col} = NaN"
                     )
                     if groupby_col:
-                        g1_mask = (df[col] == cat_val) & (df[groupby_col] == g1)
-                        g2_mask = (df[col] == cat_val) & (df[groupby_col] == g2)
+                        if pd.isna(cat_val):
+                            col_mask = df[col].isna()
+                        else:
+                            col_mask = df[col] == cat_val
+                        g1_mask = col_mask & (df[groupby_col] == g1)
+                        g2_mask = col_mask & (df[groupby_col] == g2)
                         g1_count = g1_mask.sum()
                         g2_count = g2_mask.sum()
                         g1_total = (df[groupby_col] == g1).sum()

--- a/unittests/test_data_manager.py
+++ b/unittests/test_data_manager.py
@@ -1199,6 +1199,62 @@ def test_include_types_invalid_option_raises():
         generate_table1(df, include_types="invalid_option")
 
 
+# ------------------------------------------------------------------
+# NaN handling in generate_table1
+# ------------------------------------------------------------------
+
+def test_value_counts_nan_row_has_correct_group_counts():
+    df = pd.DataFrame({
+        "x":     ["a", "a", "a", "b", "b", "b", np.nan, np.nan, np.nan, np.nan],
+        "group": ["A", "B", "A", "B", "A", "B", "A",    "B",    "A",    "B"],
+    })
+    result = generate_table1(
+        df,
+        categorical_cols=["x"],
+        continuous_cols=[],
+        groupby_col="group",
+        value_counts=True,
+    )
+
+    nan_rows = result[result["Variable"] == "x = NaN"]
+    assert len(nan_rows) == 1
+
+    nan_row = nan_rows.iloc[0]
+    # group columns are labeled like "A (n = 5)" / "B (n = 5)"
+    a_col = [c for c in result.columns if c.startswith("A ")][0]
+    b_col = [c for c in result.columns if c.startswith("B ")][0]
+
+    # bug presented as "0 (0.00%)" in both group columns
+    assert "0 (0.00%)" not in nan_row[a_col]
+    assert "0 (0.00%)" not in nan_row[b_col]
+
+
+def test_all_nan_categorical_column_emits_row_in_groupby():
+    import warnings as _warnings
+
+    df = pd.DataFrame({
+        "x":     [np.nan] * 6,
+        "group": ["A", "B", "A", "B", "A", "B"],
+    })
+
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        result = generate_table1(
+            df,
+            categorical_cols=["x"],
+            continuous_cols=[],
+            groupby_col="group",
+            value_counts=True,
+        )
+
+    # column should appear in the output, not be silently skipped
+    assert "x" in result["Variable"].values
+
+    # no "Skipping" warning should have fired
+    skip_warnings = [w for w in caught if "Skipping" in str(w.message)]
+    assert len(skip_warnings) == 0
+
+    
 def test_groupby_imputer_as_new_col_global_mean():
     df = pd.DataFrame(
         {


### PR DESCRIPTION
Fixes https://github.com/datasciencedynamics/eda_toolkit/issues/129: NaN handling in `generate_table1` under `groupby_col`.

**Changes**
- `value_counts` loop: NaN-safe `col_mask` so `x = NaN` rows show correct per-group counts (was `0 (0.00%)`).
- Categorical loop: all-NaN columns emit a placeholder row instead of being skipped by the crosstab shape check.

**Tests**
- `test_value_counts_nan_row_has_correct_group_counts`
- `test_all_nan_categorical_column_emits_row_in_groupby`

No signature changes.

Closes https://github.com/datasciencedynamics/eda_toolkit/issues/129