### PR TITLE
Add full-path image_filename saving + axis formatting

### DIFF
--- a/py_example_notebooks/adult_income_eda.ipynb
+++ b/py_example_notebooks/adult_income_eda.ipynb
@@ -194,6 +194,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "image_path_png"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "exclude_combinations = [\n",
     "    (\"capital-gain\", \"hours-per-week\"),\n",
     "    (\"capital-loss\", \"capital-gain\"),\n",
@@ -209,15 +218,16 @@
     "    all_vars=df.select_dtypes(np.number).columns.to_list(),\n",
     "    show_legend=True,\n",
     "    exclude_combinations=exclude_combinations,\n",
-    "    show_plot=\"combinations\",\n",
+    "    # show_plot=\"combinations\",\n",
     "    label_fontsize=14,\n",
     "    tick_fontsize=12,\n",
     "    add_best_fit_line=True,\n",
     "    scatter_color=\"#808080\",\n",
     "    show_correlation=True,\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
-    "    save_plots=\"grid\",\n",
+    "    # image_path_png=image_path_png,\n",
+    "    # image_path_svg=image_path_svg,\n",
+    "    # save_plots=\"subplots\",\n",
+    "    # image_filename=\"../images/png_images/scatter_fit_plot.svg\"\n",
     ")"
    ]
   },
@@ -260,9 +270,9 @@
     "    # figsize=(10, 6),\n",
     "    plot_style=\"density\",\n",
     "    label_fontsize=10,\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
-    "    image_filename=\"grouped_distributions_adult_income\",\n",
+    "    # image_path_png=image_path_png,\n",
+    "    # image_path_svg=image_path_svg,\n",
+    "    image_filename=\"grouped_distributions_adult_income.png\",\n",
     "    # tick_fontsize=16,\n",
     "    # text_wrap=10,\n",
     ")"
@@ -316,14 +326,14 @@
     "    plot_types=\"qq\",\n",
     "    qq_type=\"theoretical\",\n",
     "    show_reference=True,\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
+    "    # image_path_png=image_path_png,\n",
+    "    # image_path_svg=image_path_svg,\n",
     "    palette={\n",
     "        \"norm\": \"tab:blue\",\n",
     "        \"lognorm\": \"tab:orange\",\n",
     "        \"gamma\": \"tab:green\",\n",
     "    },\n",
-    "    image_filename=\"gof_qq_age_adult_income\",\n",
+    "    image_filename=\"gof_qq_age_adult_income.png\",\n",
     "    xlim=(5, 100),\n",
     "    ylim=(5, 100),\n",
     ")"
@@ -519,6 +529,7 @@
     "    var=\"age\",\n",
     "    dist=[\"norm\", \"lognorm\"],\n",
     "    plot_types=\"cdf\",\n",
+    "    image_filename=\"gof_cdf_age_adult_income.png\",\n",
     ")"
    ]
   },
@@ -724,9 +735,9 @@
     "    plot_type=\"both\",  # Can also just plot KDE by itself by passing \"kde\"\n",
     "    label_fontsize=16,  # Font size for axis labels\n",
     "    tick_fontsize=14,  # Font size for tick labels\n",
-    "    image_filename=\"age_distribution_kde\",\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
+    "    image_filename=\"age_distribution_kde.png\",\n",
+    "    # image_path_png=image_path_png,\n",
+    "    # image_path_svg=image_path_svg,\n",
     ")"
    ]
   },
@@ -763,7 +774,7 @@
     "    plot_type=\"hist\",\n",
     "    label_fontsize=16,  # Font size for axis labels\n",
     "    tick_fontsize=14,  # Font size for tick labels\n",
-    "    image_filename=\"age_distribution_density\",\n",
+    "    image_filename=\"age_distribution_density.png\",\n",
     "    image_path_png=image_path_png,\n",
     "    image_path_svg=image_path_svg,\n",
     ")"
@@ -803,7 +814,7 @@
     "    stat=\"Count\",\n",
     "    label_fontsize=16,  # Font size for axis labels\n",
     "    tick_fontsize=14,  # Font size for tick labels\n",
-    "    image_filename=\"age_distribution_count\",\n",
+    "    image_filename=\"age_distribution_count.png\",\n",
     "    image_path_png=image_path_png,\n",
     "    image_path_svg=image_path_svg,\n",
     ")"
@@ -847,7 +858,7 @@
     "    plot_mean=True,\n",
     "    plot_median=True,\n",
     "    mean_color=\"blue\",\n",
-    "    image_filename=\"age_distribution_mean_median\",\n",
+    "    image_filename=\"age_distribution_mean_median.png\",\n",
     "    image_path_png=image_path_png,\n",
     "    image_path_svg=image_path_svg,\n",
     ")"
@@ -899,7 +910,7 @@
     "        \"green\",\n",
     "        \"silver\",\n",
     "    ],\n",
-    "    image_filename=\"age_distribution_mean_median_std\",\n",
+    "    image_filename=\"age_distribution_mean_median_std.png\",\n",
     ")"
    ]
   },
@@ -937,7 +948,7 @@
     "    tick_fontsize=14,\n",
     "    legend_loc=\"best\",\n",
     "    bbox_inches=\"tight\",\n",
-    "    image_filename=\"age_distribution_norm_fit\",\n",
+    "    image_filename=\"age_distribution_norm_fit.png\",\n",
     "    image_path_png=image_path_png,\n",
     "    image_path_svg=image_path_svg,\n",
     ")"
@@ -984,9 +995,9 @@
     "    apply_as_new_col_to_df=True,\n",
     "    random_state=111,\n",
     "    figsize=(10, 3),\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
-    "    image_filename=\"data_doctor_age_box_cox_adult_income\",\n",
+    "    # image_path_png=image_path_png,\n",
+    "    # image_path_svg=image_path_svg,\n",
+    "    image_filename=\"data_doctor_age_box_cox_adult_income.png\",\n",
     ")"
    ]
   },
@@ -1031,7 +1042,7 @@
     "    figsize=(10, 3),\n",
     "    image_path_png=image_path_png,\n",
     "    image_path_svg=image_path_svg,\n",
-    "    image_filename=\"data_doctor_age_box_cox_full_data_adult_income\",\n",
+    "    image_filename=\"data_doctor_age_box_cox_full_data_adult_income.png\",\n",
     ")"
    ]
   },
@@ -1258,10 +1269,11 @@
     "    show_legend=True,\n",
     "    label_fontsize=14,\n",
     "    tick_fontsize=12,\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
+    "    # image_path_png=image_path_png,\n",
+    "    # image_path_svg=image_path_svg,\n",
+    "    image_filename=\"stacked_bar_adult_income.png\",\n",
     "    file_prefix=\"stacked_bar\",\n",
-    "    save_formats=[\"png\", \"svg\"],\n",
+    "    # save_formats=[\"png\", \"svg\"],\n",
     ")"
    ]
   },
@@ -1414,9 +1426,9 @@
     "    df=df,\n",
     "    metrics_list=age_boxplot_list,\n",
     "    metrics_comp=metrics_comp,\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
-    "    image_filename=\"adult_income_boxplot\",\n",
+    "    # image_path_png=image_path_png,\n",
+    "    # image_path_svg=image_path_svg,\n",
+    "    image_filename=\"adult_income_boxplot.png\",\n",
     "    show_plot=\"both\",\n",
     "    show_legend=False,\n",
     "    plot_type=\"boxplot\",\n",
@@ -1673,9 +1685,10 @@
     "    vmax=1,\n",
     "    cbar_label=\"Correlation Index\",\n",
     "    triangular=True,\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
-    "    save_plots=True,\n",
+    "    image_filename=\"adult_income_corr_matrix.png\",\n",
+    "    # image_path_png=image_path_png,\n",
+    "    # image_path_svg=image_path_svg,\n",
+    "    # save_plots=True,\n",
     ")"
    ]
   },
@@ -1802,6 +1815,7 @@
     "    normalize=False,\n",
     "    image_path_svg=image_path_svg,\n",
     "    image_path_png=image_path_png,\n",
+    "    image_filename=\"outcome_by_feature.png\",\n",
     "    string=\"outcome_by_feature\",\n",
     "    save_plots=True,\n",
     "    outcome=\"income\",\n",
@@ -1812,7 +1826,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "eda_venv_311",
+   "display_name": "etkit_venv (3.12.7)",
    "language": "python",
    "name": "python3"
   },
@@ -1826,7 +1840,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/py_example_notebooks/adult_income_eda.ipynb
+++ b/py_example_notebooks/adult_income_eda.ipynb
@@ -224,10 +224,8 @@
     "    add_best_fit_line=True,\n",
     "    scatter_color=\"#808080\",\n",
     "    show_correlation=True,\n",
-    "    # image_path_png=image_path_png,\n",
-    "    # image_path_svg=image_path_svg,\n",
-    "    # save_plots=\"subplots\",\n",
-    "    # image_filename=\"../images/png_images/scatter_fit_plot.svg\"\n",
+    "    save_plots=\"subplots\",\n",
+    "    image_filename=\"../images/png_images/scatter_fit_plot.png\"\n",
     ")"
    ]
   },
@@ -270,9 +268,7 @@
     "    # figsize=(10, 6),\n",
     "    plot_style=\"density\",\n",
     "    label_fontsize=10,\n",
-    "    # image_path_png=image_path_png,\n",
-    "    # image_path_svg=image_path_svg,\n",
-    "    image_filename=\"grouped_distributions_adult_income.png\",\n",
+    "    image_filename=\"../images/png_images/grouped_distributions_adult_income.png\",\n",
     "    # tick_fontsize=16,\n",
     "    # text_wrap=10,\n",
     ")"
@@ -326,14 +322,12 @@
     "    plot_types=\"qq\",\n",
     "    qq_type=\"theoretical\",\n",
     "    show_reference=True,\n",
-    "    # image_path_png=image_path_png,\n",
-    "    # image_path_svg=image_path_svg,\n",
     "    palette={\n",
     "        \"norm\": \"tab:blue\",\n",
     "        \"lognorm\": \"tab:orange\",\n",
     "        \"gamma\": \"tab:green\",\n",
     "    },\n",
-    "    image_filename=\"gof_qq_age_adult_income.png\",\n",
+    "    image_filename=\"../images/png_images/gof_qq_age_adult_income.png\",\n",
     "    xlim=(5, 100),\n",
     "    ylim=(5, 100),\n",
     ")"
@@ -529,7 +523,7 @@
     "    var=\"age\",\n",
     "    dist=[\"norm\", \"lognorm\"],\n",
     "    plot_types=\"cdf\",\n",
-    "    image_filename=\"gof_cdf_age_adult_income.png\",\n",
+    "    image_filename=\"../images/png_images/gof_cdf_age_adult_income.png\",\n",
     ")"
    ]
   },
@@ -629,9 +623,7 @@
     "    dist=[\"norm\", \"lognorm\", \"gamma\"],\n",
     "    plot_types=[\"qq\", \"cdf\"],\n",
     "    show_reference=False,\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
-    "    image_filename=\"gof_qq_cdf_age_adult_income\",\n",
+    "    image_filename=\"../images/png_images/gof_qq_cdf_age_adult_income.png\",\n",
     ")"
    ]
   },
@@ -735,9 +727,7 @@
     "    plot_type=\"both\",  # Can also just plot KDE by itself by passing \"kde\"\n",
     "    label_fontsize=16,  # Font size for axis labels\n",
     "    tick_fontsize=14,  # Font size for tick labels\n",
-    "    image_filename=\"age_distribution_kde.png\",\n",
-    "    # image_path_png=image_path_png,\n",
-    "    # image_path_svg=image_path_svg,\n",
+    "    image_filename=\"../images/png_images/age_distribution_kde.png\",\n",
     ")"
    ]
   },
@@ -774,9 +764,7 @@
     "    plot_type=\"hist\",\n",
     "    label_fontsize=16,  # Font size for axis labels\n",
     "    tick_fontsize=14,  # Font size for tick labels\n",
-    "    image_filename=\"age_distribution_density.png\",\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
+    "    image_filename=\"../images/png_images/age_distribution_density.png\",\n",
     ")"
    ]
   },
@@ -814,9 +802,7 @@
     "    stat=\"Count\",\n",
     "    label_fontsize=16,  # Font size for axis labels\n",
     "    tick_fontsize=14,  # Font size for tick labels\n",
-    "    image_filename=\"age_distribution_count.png\",\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
+    "    image_filename=\"../images/png_images/age_distribution_count.png\",\n",
     ")"
    ]
   },
@@ -858,9 +844,7 @@
     "    plot_mean=True,\n",
     "    plot_median=True,\n",
     "    mean_color=\"blue\",\n",
-    "    image_filename=\"age_distribution_mean_median.png\",\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
+    "    image_filename=\"../images/png_images/age_distribution_mean_median.png\",\n",
     ")"
    ]
   },
@@ -898,8 +882,6 @@
     "    plot_mean=True,\n",
     "    plot_median=True,\n",
     "    mean_color=\"blue\",\n",
-    "    image_path_svg=image_path_svg,\n",
-    "    image_path_png=image_path_png,\n",
     "    std_dev_levels=[\n",
     "        1,\n",
     "        2,\n",
@@ -910,7 +892,7 @@
     "        \"green\",\n",
     "        \"silver\",\n",
     "    ],\n",
-    "    image_filename=\"age_distribution_mean_median_std.png\",\n",
+    "    image_filename=\"../images/png_images/age_distribution_mean_median_std.png\",\n",
     ")"
    ]
   },
@@ -948,9 +930,7 @@
     "    tick_fontsize=14,\n",
     "    legend_loc=\"best\",\n",
     "    bbox_inches=\"tight\",\n",
-    "    image_filename=\"age_distribution_norm_fit.png\",\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
+    "    image_filename=\"../images/png_images/age_distribution_norm_fit.png\",\n",
     ")"
    ]
   },
@@ -995,9 +975,7 @@
     "    apply_as_new_col_to_df=True,\n",
     "    random_state=111,\n",
     "    figsize=(10, 3),\n",
-    "    # image_path_png=image_path_png,\n",
-    "    # image_path_svg=image_path_svg,\n",
-    "    image_filename=\"data_doctor_age_box_cox_adult_income.png\",\n",
+    "    image_filename=\"../images/png_images/data_doctor_age_box_cox_adult_income.png\",\n",
     ")"
    ]
   },
@@ -1040,9 +1018,7 @@
     "    hist_kws={\"color\": \"green\"},\n",
     "    random_state=111,\n",
     "    figsize=(10, 3),\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
-    "    image_filename=\"data_doctor_age_box_cox_full_data_adult_income.png\",\n",
+    "    image_filename=\"../images/png_images/data_doctor_age_box_cox_full_data_adult_income.png\",\n",
     ")"
    ]
   },
@@ -1102,9 +1078,7 @@
     "    plot_type=[\"box_violin\", \"hist\"],\n",
     "    hist_kws={\"color\": \"gray\"},\n",
     "    figsize=(8, 4),\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
-    "    image_filename=\"data_doctor_fnlwgt_adult_income\",\n",
+    "    image_filename=\"../images/png_images/data_doctor_fnlwgt_adult_income.png\",\n",
     "    random_state=111,\n",
     ")"
    ]
@@ -1132,9 +1106,7 @@
     "    plot_type=[\"box_violin\", \"hist\"],\n",
     "    hist_kws={\"color\": \"gray\", \"bins\": 20},\n",
     "    figsize=(8, 4),\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
-    "    image_filename=\"data_doctor_fnlwgt_cutoff_adult_income\",\n",
+    "    image_filename=\"../images/png_images/data_doctor_fnlwgt_cutoff_adult_income.png\",\n",
     "    random_state=111,\n",
     ")"
    ]
@@ -1163,9 +1135,7 @@
     "        \"quantile_range\": (10.0, 90.0),  # Use a custom quantile range\n",
     "    },\n",
     "    random_state=111,\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
-    "    image_filename=\"data_doctor_age_robust_scaling_adult_income\",\n",
+    "    image_filename=\"../images/png_images/data_doctor_age_robust_scaling_adult_income.png\",\n",
     ")"
    ]
   },
@@ -1189,9 +1159,7 @@
     "    feature_name=\"age\",\n",
     "    plot_type=[\"ecdf\", \"box_violin\"],\n",
     "    scale_conversion=\"log\",\n",
-    "    image_filename=\"data_doctor_age_ecdf_log_scale_adult_income\",\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
+    "    image_filename=\"../images/png_images/data_doctor_age_ecdf_log_scale_adult_income.png\",\n",
     "    figsize=(12, 6),\n",
     "    label_fontsize=16,\n",
     "    tick_fontsize=14,\n",
@@ -1269,11 +1237,7 @@
     "    show_legend=True,\n",
     "    label_fontsize=14,\n",
     "    tick_fontsize=12,\n",
-    "    # image_path_png=image_path_png,\n",
-    "    # image_path_svg=image_path_svg,\n",
-    "    image_filename=\"stacked_bar_adult_income.png\",\n",
-    "    file_prefix=\"stacked_bar\",\n",
-    "    # save_formats=[\"png\", \"svg\"],\n",
+    "    image_filename=\"../images/png_images/stacked_bar_adult_income.png\",\n",
     ")"
    ]
   },
@@ -1338,10 +1302,7 @@
     "    show_legend=True,\n",
     "    label_fontsize=14,\n",
     "    tick_fontsize=12,\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
-    "    file_prefix=\"stacked_bar_non_normalized\",\n",
-    "    save_formats=[\"png\", \"svg\"],\n",
+    "    image_filename=\"../images/png_images/stacked_bar_non_normalized.png\",\n",
     ")"
    ]
   },
@@ -1379,10 +1340,7 @@
     "    label_fontsize=14,\n",
     "    tick_fontsize=12,\n",
     "    remove_stacks=True,\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
-    "    file_prefix=\"unstacked_bar\",\n",
-    "    save_formats=[\"png\", \"svg\"],\n",
+    "    image_filename=\"../images/png_images/unstacked_bar.png\",\n",
     ")"
    ]
   },
@@ -1426,9 +1384,7 @@
     "    df=df,\n",
     "    metrics_list=age_boxplot_list,\n",
     "    metrics_comp=metrics_comp,\n",
-    "    # image_path_png=image_path_png,\n",
-    "    # image_path_svg=image_path_svg,\n",
-    "    image_filename=\"adult_income_boxplot.png\",\n",
+    "    image_filename=\"../images/png_images/adult_income_boxplot.png\",\n",
     "    show_plot=\"both\",\n",
     "    show_legend=False,\n",
     "    plot_type=\"boxplot\",\n",
@@ -1455,9 +1411,7 @@
     "    df=df,\n",
     "    metrics_list=age_boxplot_list,\n",
     "    metrics_comp=metrics_comp,\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
-    "    image_filename=\"adult_income_violin_subplots\",\n",
+    "    image_filename=\"../images/png_images/adult_income_violin_subplots.png\",\n",
     "    show_plot=\"both\",\n",
     "    show_legend=False,\n",
     "    plot_type=\"violinplot\",\n",
@@ -1534,8 +1488,7 @@
     "    add_best_fit_line=True,\n",
     "    scatter_color=\"#808080\",\n",
     "    show_correlation=True,\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
+    "    image_filename=\"../images/png_images/scatter_fit_plot.png\",\n",
     "    save_plots=\"all\",\n",
     ")"
    ]
@@ -1570,8 +1523,7 @@
     "    hue=\"income\",\n",
     "    hue_palette=hue_dict,\n",
     "    show_correlation=False,\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
+    "    image_filename=\"../images/png_images/scatter_fit_plot.png\",\n",
     "    save_plots=\"all\",\n",
     ")"
    ]
@@ -1599,8 +1551,7 @@
     "    add_best_fit_line=True,\n",
     "    scatter_color=\"#808080\",\n",
     "    show_correlation=True,\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
+    "    image_filename=\"../images/png_images/scatter_fit_plot.png\",\n",
     "    save_plots=\"all\",\n",
     ")"
    ]
@@ -1632,8 +1583,7 @@
     "    add_best_fit_line=True,\n",
     "    scatter_color=\"#808080\",\n",
     "    show_correlation=True,\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
+    "    image_filename=\"../images/png_images/scatter_fit_plot.png\",\n",
     "    save_plots=\"grid\",\n",
     ")"
    ]
@@ -1685,10 +1635,7 @@
     "    vmax=1,\n",
     "    cbar_label=\"Correlation Index\",\n",
     "    triangular=True,\n",
-    "    image_filename=\"adult_income_corr_matrix.png\",\n",
-    "    # image_path_png=image_path_png,\n",
-    "    # image_path_svg=image_path_svg,\n",
-    "    # save_plots=True,\n",
+    "    image_filename=\"../images/png_images/adult_income_corr_matrix.png\",\n",
     ")"
    ]
   },
@@ -1705,7 +1652,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flex_corr_matrix(\n",
+    "corr_tri_sig = flex_corr_matrix(\n",
     "    df=df,\n",
     "    cols=df_num.columns.to_list(),\n",
     "    annot=True,\n",
@@ -1722,11 +1669,53 @@
     "    vmax=1,\n",
     "    cbar_label=\"Correlation Index\",\n",
     "    triangular=True,\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
     "    show_significance=True,\n",
-    "    image_filename=\"correlation_matrix_stat_sig\",\n",
-    "    save_plots=True,\n",
+    "    image_filename=\"../images/png_images/correlation_matrix_stat_sig.png\",\n",
+    "    return_corr=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "corr_tri_sig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Subset by Threshold Cutoff"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flex_corr_matrix(\n",
+    "    df=df,\n",
+    "    cols=df_num.columns.to_list(),\n",
+    "    annot=True,\n",
+    "    cmap=\"coolwarm\",\n",
+    "    figsize=(20, 4),\n",
+    "    title=\"US Census Correlation Matrix\",\n",
+    "    xlabel_alignment=\"right\",\n",
+    "    label_fontsize=14,\n",
+    "    tick_fontsize=12,\n",
+    "    xlabel_rot=45,\n",
+    "    ylabel_rot=0,\n",
+    "    text_wrap=50,\n",
+    "    vmin=-1,\n",
+    "    vmax=1,\n",
+    "    corr_threshold=0.08,\n",
+    "    cbar_label=\"Correlation Index\",\n",
+    "    triangular=True,\n",
+    "    image_filename=\"../images/png_images/adult_income_threshold_corr_matrix.png\",\n",
     ")"
    ]
   },
@@ -1760,10 +1749,44 @@
     "    vmax=1,\n",
     "    cbar_label=\"Correlation Index\",\n",
     "    triangular=False,\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_path_svg=image_path_svg,\n",
-    "    save_plots=True,\n",
+    "    image_filename=\"../images/png_images/adult_income_corr_tri_matrix.png\",\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "corr_df = flex_corr_matrix(\n",
+    "    df=df,\n",
+    "    cols=df_num.columns.to_list(),\n",
+    "    annot=True,\n",
+    "    cmap=\"viridis\",\n",
+    "    figsize=(10, 8),\n",
+    "    title=\"US Census Correlation Matrix\",\n",
+    "    xlabel_alignment=\"right\",\n",
+    "    label_fontsize=14,\n",
+    "    tick_fontsize=12,\n",
+    "    xlabel_rot=45,\n",
+    "    ylabel_rot=0,\n",
+    "    text_wrap=50,\n",
+    "    vmin=-1,\n",
+    "    vmax=1,\n",
+    "    cbar_label=\"Correlation Index\",\n",
+    "    triangular=False,\n",
+    "    return_corr=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "corr_df"
    ]
   },
   {
@@ -1813,9 +1836,7 @@
     "    label_1=\">50K\",\n",
     "    figsize=(10, 6),\n",
     "    normalize=False,\n",
-    "    image_path_svg=image_path_svg,\n",
-    "    image_path_png=image_path_png,\n",
-    "    image_filename=\"outcome_by_feature.png\",\n",
+    "    image_filename=\"../images/png_images/outcome_by_feature.png\",\n",
     "    string=\"outcome_by_feature\",\n",
     "    save_plots=True,\n",
     "    outcome=\"income\",\n",

--- a/src/eda_toolkit/_plot_utils.py
+++ b/src/eda_toolkit/_plot_utils.py
@@ -50,6 +50,16 @@ def _save_figure(
     if image_path_svg:
         targets.append(os.path.join(image_path_svg, f"{stem}.svg"))
 
+    # A filename was provided but nothing was saveable: bare stem, no extension,
+    # no output directory. Fail loudly instead of silently no-op'ing.
+    if not targets:
+        raise ValueError(
+            f"Cannot save figure: `image_filename='{image_filename}'` has no "
+            "file extension and no `image_path_png` / `image_path_svg` was given. "
+            "Add an extension (e.g. '.png', '.jpg', '.svg') or pass an output "
+            "directory."
+        )
+
     for path in targets:
         directory = os.path.dirname(path)
         if directory:

--- a/src/eda_toolkit/_plot_utils.py
+++ b/src/eda_toolkit/_plot_utils.py
@@ -2,11 +2,11 @@ import numpy as np
 import pandas as pd
 import os
 import matplotlib.pyplot as plt
+import matplotlib.ticker as mticker
 import seaborn as sns
 import scipy.stats as stats
 import warnings
 from typing import Optional, List, Dict, Union, Tuple
-
 
 ################################################################################
 # Figure Saving Utility
@@ -15,62 +15,62 @@ from typing import Optional, List, Dict, Union, Tuple
 
 def _save_figure(
     *,
-    fig: Optional[plt.Figure] = None,
-    image_path_png: Optional[str] = None,
-    image_path_svg: Optional[str] = None,
-    filename: Optional[str] = None,
-    bbox_inches: str = "tight",
-    dpi: Optional[int] = None,
-) -> None:
+    fig=None,
+    image_path_png=None,
+    image_path_svg=None,
+    image_filename=None,
+    filename=None,  # legacy alias, keeps old call sites working
+    bbox_inches="tight",
+    dpi=None,
+):
     """
     Save a matplotlib figure to PNG and/or SVG.
 
-    This helper centralizes all figure-saving logic. Callers provide
-    output directories and a base filename. Full file paths are
-    constructed internally.
-
-    Parameters
-    ----------
-    fig : matplotlib.figure.Figure or None
-        Figure to save. If None, uses the current active figure.
-
-    image_path_png : str or None
-        Directory path where the PNG file should be saved.
-        If None, PNG output is skipped.
-
-    image_path_svg : str or None
-        Directory path where the SVG file should be saved.
-        If None, SVG output is skipped.
-
-    filename : str or None
-        Base filename without extension. If None, no files are saved.
-
-    bbox_inches : str, optional
-        Bounding box option passed to savefig.
-
-    dpi : int or None, optional
-        DPI for raster outputs such as PNG.
+    If ``image_filename`` has an extension it is saved verbatim (no directory
+    needed); otherwise it is used as a stem with ``image_path_png`` /
+    ``image_path_svg``. ``filename`` is a legacy alias for ``image_filename``.
     """
-    # Nothing to do
-    if filename is None or (image_path_png is None and image_path_svg is None):
+    # accept the old `filename` keyword as an alias for `image_filename`
+    if image_filename is None:
+        image_filename = filename
+    if image_filename is None:
         return
-
     fig = fig or plt.gcf()
 
-    if image_path_png:
-        png_path = os.path.join(image_path_png, f"{filename}.png")
-        fig.savefig(
-            png_path,
-            bbox_inches=bbox_inches,
-            dpi=dpi,
-        )
+    stem, ext = os.path.splitext(os.path.basename(image_filename))
+    targets = []
 
+    # full path with extension -> save verbatim, no dirs required
+    if ext:
+        targets.append(image_filename)
+
+    # legacy: directory + base name, one file per requested format
+    if image_path_png:
+        targets.append(os.path.join(image_path_png, f"{stem}.png"))
     if image_path_svg:
-        svg_path = os.path.join(image_path_svg, f"{filename}.svg")
-        fig.savefig(
-            svg_path,
-            bbox_inches=bbox_inches,
-        )
+        targets.append(os.path.join(image_path_svg, f"{stem}.svg"))
+
+    for path in targets:
+        directory = os.path.dirname(path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+        fig.savefig(path, bbox_inches=bbox_inches, dpi=dpi)  # dpi ignored for vector
+
+
+def _resolve_save_name(user_filename, auto_stem, multi=False):
+    """Build the per-figure save name.
+    Single-file callers (multi=False) get the user's exact filename.
+    Multi-file callers (multi=True) keep the user's dir + extension but
+    use the auto name so the many files stay distinct."""
+    if not user_filename:
+        return auto_stem  # dirs-only (legacy)
+    directory, base = os.path.split(user_filename)
+    _, ext = os.path.splitext(base)
+    if not ext:  # bare path -> directory
+        return os.path.join(user_filename, auto_stem)
+    if multi:
+        return os.path.join(directory, f"{auto_stem}{ext}")
+    return user_filename  # single file -> honor it
 
 
 ################################################################################
@@ -91,6 +91,7 @@ def _apply_legend(ax, labels, loc, fontsize, reverse, bbox_to_anchor=None, ncols
         bbox_to_anchor=bbox_to_anchor,
         ncols=ncols,
     )
+
 
 # Helper: annotate stacked bar segments with values
 def _annotate_stacked(ax, data, fmt_func, kind, tick_fontsize):
@@ -125,7 +126,7 @@ def _annotate_stacked(ax, data, fmt_func, kind, tick_fontsize):
 
 
 ################################################################################
-# Best-Fit Line Utilitys
+# Best-Fit Line Utilities
 ################################################################################
 
 
@@ -189,6 +190,18 @@ def _get_palette(n_colors):
     Returns a 'tab10' color palette with the specified number of colors.
     """
     return sns.color_palette("tab10", n_colors=n_colors)
+
+
+def _apply_thousands(ax, axis="both"):
+    """Comma-group numeric tick labels while preserving decimals.
+
+    axis : "both", "x", or "y" — caller picks the numeric axis/axes.
+    """
+    fmt = mticker.FuncFormatter(lambda v, _: f"{v:,.10g}")
+    for a in (
+        (ax.xaxis, ax.yaxis) if axis == "both" else (getattr(ax, f"{axis}axis"),)
+    ):
+        a.set_major_formatter(fmt)
 
 
 ################################################################################

--- a/src/eda_toolkit/plots.py
+++ b/src/eda_toolkit/plots.py
@@ -11,7 +11,7 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 import matplotlib.pyplot as plt
 from matplotlib.colors import ListedColormap
 from matplotlib import gridspec
-import matplotlib.ticker as mticker  
+import matplotlib.ticker as mticker
 from matplotlib.ticker import FuncFormatter
 import seaborn as sns
 import textwrap
@@ -28,17 +28,18 @@ PathLike = Union[str, Path]
 
 from ._plot_utils import (
     _save_figure,
+    _resolve_save_name,
     _apply_legend,
     _annotate_stacked,
     _add_best_fit,
     _get_label,
+    _apply_thousands,
     _plot_density_overlays,
     _fit_distribution,
     _qq_plot,
     _cdf_exceedance_plot,
     _get_palette,
 )
-
 
 ################################################################################
 ############################## Plot Distributions ##############################
@@ -47,8 +48,7 @@ from ._plot_utils import (
 
 def kde_distributions(*args, **kwargs):
     warnings.warn(
-        "`kde_distributions` is deprecated and will be removed in a future release. "
-        "Use `plot_distributions` instead.",
+        "`kde_distributions` is deprecated. Use `plot_distributions` instead.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -134,8 +134,8 @@ def plot_distributions(
     hist_color : str, optional (default='#0000FF')
         Color of the histogram bars.
 
-    density_color : str, optional (default='#FF0000')
-        Color of the KDE plot.
+    density_color : str, optional (default=None)
+        Color of the KDE / density curve.
 
     mean_color : str, optional (default='#000000')
         Color of the mean line if `plot_mean` is True.
@@ -177,16 +177,21 @@ def plot_distributions(
         Directory path to save the SVG image of the overall distribution plots.
 
     image_filename : str, optional
-        Filename to use when saving the overall distribution plots.
+        Filename for the overall (subplot grid) figure. If it includes a file
+        extension it is saved verbatim and no output directory is required;
+        otherwise it is used as a base stem with ``image_path_png`` and/or
+        ``image_path_svg``.
 
     bbox_inches : str, optional
         Bounding box to use when saving the figure. For example, 'tight'.
 
     single_var_image_filename : str, optional
-        Filename to use when saving the separate distribution plots. The
-        variable name will be appended to this filename. When using this
-        parameter, the `figsize` parameter is used to determine the size of the
-        individual plots. The `subplot_figsize` parameter is ignored in this context.
+        Filename for the separate per-variable plots. May be a bare stem
+        (legacy: requires ``image_path_png`` / ``image_path_svg``) or a full
+        path with extension (saved verbatim, no directory needed). The
+        variable name is appended to the stem, before the extension. When this
+        is used, ``figsize`` controls the individual plot size and
+        ``subplot_figsize`` is ignored.
 
     y_axis_label : str, optional (default='Density')
         The label to display on the y-axis. If set to `None`, no y-axis label
@@ -275,7 +280,7 @@ def plot_distributions(
     Raises:
     -------
     ValueError
-        If `plot_type` is not one of ['hist', 'kde', 'both'].
+        If `plot_type` is not one of ['hist', 'density', 'both'].
 
     ValueError
         If `stat` is not one of ['count', 'frequency', 'probability',
@@ -630,12 +635,13 @@ def plot_distributions(
     plt.tight_layout(w_pad=w_pad, h_pad=h_pad)
 
     # Save files if paths are provided
-    if image_path_png or image_path_svg:
+    if image_path_png or image_path_svg or image_filename:
         _save_figure(
             fig=fig,
             image_path_png=image_path_png,
             image_path_svg=image_path_svg,
             filename=image_filename,
+            image_filename=image_filename,
         )
     plt.show()
 
@@ -821,21 +827,23 @@ def plot_distributions(
 
             plt.tight_layout()
 
-            # Save files for the variable of interest if paths are provided
-            if image_path_png and single_var_image_filename:
-                plt.savefig(
-                    os.path.join(
-                        image_path_png,
-                        f"{single_var_image_filename}_{var}.png",
-                    ),
-                    bbox_inches=bbox_inches,
+            # Save files for the variable of interest if a target is provided.
+            # single_var_image_filename may be a bare base name (legacy: needs a
+            # directory) or a full path with extension (saves verbatim, no dir).
+            if single_var_image_filename:
+                directory, base = os.path.split(single_var_image_filename)
+                stem, ext = os.path.splitext(base)
+                per_var_stem = f"{stem}_{var}"
+                per_var_path = (
+                    os.path.join(directory, f"{per_var_stem}{ext}")
+                    if ext
+                    else per_var_stem
                 )
-            if image_path_svg and single_var_image_filename:
-                plt.savefig(
-                    os.path.join(
-                        image_path_svg,
-                        f"{single_var_image_filename}_{var}.svg",
-                    ),
+                _save_figure(
+                    fig=fig,
+                    image_path_png=image_path_png,
+                    image_path_svg=image_path_svg,
+                    image_filename=per_var_path,
                     bbox_inches=bbox_inches,
                 )
             plt.close(
@@ -846,6 +854,7 @@ def plot_distributions(
 ################################################################################
 ###################### Stacked Bar Plots W/ Crosstab Options ###################
 ################################################################################
+
 
 def stacked_crosstab_plot(
     df: pd.DataFrame,
@@ -860,6 +869,7 @@ def stacked_crosstab_plot(
     image_path_png: Optional[str] = None,
     image_path_svg: Optional[str] = None,
     save_formats: Optional[List[str]] = None,
+    image_filename: Optional[str] = None,
     color: Optional[Union[List[str], str]] = None,
     output: str = "both",
     return_dict: bool = False,
@@ -930,10 +940,21 @@ def stacked_crosstab_plot(
     image_path_svg : str, optional
         Directory path where generated SVG plot images will be saved.
 
+    image_filename : str, optional
+        Full destination path for the saved plot(s). If it includes an
+        extension, that extension selects the format unless ``save_formats``
+        is given; the file is saved verbatim and no directory is required. The
+        ``func_col`` entry is appended to the stem so each generated figure
+        stays distinct. When provided, ``image_filename`` takes precedence over
+        the ``image_path_png`` / ``image_path_svg`` directory scheme.
+
     save_formats : list of str, optional (default=None)
-        List of file formats to save the plot images in. Valid formats are
-        'png' and 'svg'. If not provided, defaults to an empty list and no
-        images will be saved.
+        File formats to write ('png' and/or 'svg'). With the
+        ``image_path_png`` / ``image_path_svg`` scheme these select which
+        directories are written. With ``image_filename`` they select which
+        formats are written; if omitted there, the format is taken from the
+        filename's extension (defaulting to 'png'). If neither a directory nor
+        ``image_filename`` is given, nothing is saved.
 
     color : list of str, optional
         List of colors to use for the plots. If not provided, a default
@@ -1057,8 +1078,8 @@ def stacked_crosstab_plot(
         If any columns in `col` or `func_col` are missing in the DataFrame.
 
     ValueError
-        If an invalid save format is specified without providing the
-        corresponding image path.
+        If a format in `save_formats` is not an available save target (no
+        corresponding image path, or not derivable from `image_filename`).
     """
 
     # Check if remove_stacks is used correctly
@@ -1084,7 +1105,7 @@ def stacked_crosstab_plot(
     # Normalize subtitle to a list if a bare string is passed
     if isinstance(subtitle, str):
         subtitle = [subtitle] * len(func_col)
- 
+
     # Validate subtitle length if provided
     if subtitle is not None and len(subtitle) != len(func_col):
         raise ValueError(
@@ -1154,17 +1175,28 @@ def stacked_crosstab_plot(
         ):
             image_path = {}
 
-            if image_path_png:
-                func_col_filename_png = os.path.join(
-                    image_path_png, f"{file_prefix}_{truth}.png"
-                )
-                image_path["png"] = func_col_filename_png
-
-            if image_path_svg:
-                func_col_filename_svg = os.path.join(
-                    image_path_svg, f"{file_prefix}_{truth}.svg"
-                )
-                image_path["svg"] = func_col_filename_svg
+            if image_filename:
+                # image_filename drives the destination; save_formats (or the
+                # filename's own extension) drive which formats are written
+                if_dir, if_base = os.path.split(image_filename)
+                if_stem, if_ext = os.path.splitext(if_base)
+                base_stem = f"{if_stem}_{truth}"
+                fmts = save_formats or ([if_ext.lstrip(".")] if if_ext else ["png"])
+                for fmt in fmts:
+                    image_path[fmt] = (
+                        os.path.join(if_dir, f"{base_stem}.{fmt}")
+                        if if_dir
+                        else f"{base_stem}.{fmt}"
+                    )
+            else:
+                if image_path_png:
+                    image_path["png"] = os.path.join(
+                        image_path_png, f"{file_prefix}_{truth}.png"
+                    )
+                if image_path_svg:
+                    image_path["svg"] = os.path.join(
+                        image_path_svg, f"{file_prefix}_{truth}.svg"
+                    )
 
             fig, axes = plt.subplots(nrows=nrows, ncols=1, figsize=figsize)
 
@@ -1256,7 +1288,9 @@ def stacked_crosstab_plot(
                             )
 
                 if show_legend:
-                    _apply_legend(ax0, legend, legend_loc, label_fontsize, reverse_legend)
+                    _apply_legend(
+                        ax0, legend, legend_loc, label_fontsize, reverse_legend
+                    )
                 else:
                     leg = ax0.get_legend()
                     if leg is not None:
@@ -1351,7 +1385,9 @@ def stacked_crosstab_plot(
                         )
 
                     if show_legend:
-                        _apply_legend(ax0, legend, legend_loc, label_fontsize, reverse_legend)
+                        _apply_legend(
+                            ax0, legend, legend_loc, label_fontsize, reverse_legend
+                        )
                     else:
                         leg = ax0.get_legend()
                         if leg is not None:
@@ -1404,9 +1440,7 @@ def stacked_crosstab_plot(
 
                     # Apply percentage formatter to the normalized count axis
                     if pct_format:
-                        pct_fmt = mticker.FuncFormatter(
-                            lambda val, _: f"{val:.0%}"
-                        )
+                        pct_fmt = mticker.FuncFormatter(lambda val, _: f"{val:.0%}")
                         if kind == "barh":
                             ax1.xaxis.set_major_formatter(pct_fmt)
                         else:
@@ -1442,7 +1476,9 @@ def stacked_crosstab_plot(
                         )
 
                     if show_legend:
-                        _apply_legend(ax1, legend, legend_loc, label_fontsize, reverse_legend)
+                        _apply_legend(
+                            ax1, legend, legend_loc, label_fontsize, reverse_legend
+                        )
                     else:
                         leg = ax1.get_legend()
                         if leg is not None:
@@ -1469,12 +1505,15 @@ def stacked_crosstab_plot(
             elif isinstance(save_formats, tuple):
                 save_formats = list(save_formats)
 
-            # Check for invalid save formats
-            valid_formats = []
-            if image_path_png:
-                valid_formats.append("png")
-            if image_path_svg:
-                valid_formats.append("svg")
+            # Determine which formats are valid targets
+            if image_filename:
+                valid_formats = list(image_path.keys())
+            else:
+                valid_formats = []
+                if image_path_png:
+                    valid_formats.append("png")
+                if image_path_svg:
+                    valid_formats.append("svg")
 
             # Throw an error if an invalid format is specified
             for save_format in save_formats:
@@ -1486,12 +1525,19 @@ def stacked_crosstab_plot(
                         f"Valid options are: {valid_formats}"
                     )
 
-            if save_formats and isinstance(image_path, dict):
-                for save_format in save_formats:
-                    if save_format in image_path:
-                        full_path = image_path[save_format]
-                        plt.savefig(full_path, bbox_inches="tight")
-                        print(f"Plot saved as {full_path}")
+            # image_filename writes every resolved target; the legacy dir path
+            # still filters by save_formats exactly as before
+            if image_filename:
+                to_save = list(image_path.values())
+            else:
+                to_save = [image_path[f] for f in save_formats if f in image_path]
+
+            for full_path in to_save:
+                directory = os.path.dirname(full_path)
+                if directory:
+                    os.makedirs(directory, exist_ok=True)
+                plt.savefig(full_path, bbox_inches="tight")
+                print(f"Plot saved as {full_path}")
 
             plt.show()
 
@@ -1560,6 +1606,7 @@ def stacked_crosstab_plot(
 ############################ Box and Violin Plots ##############################
 ################################################################################
 
+
 def box_violin_plot(
     df: pd.DataFrame,
     metrics_list: List[str],
@@ -1597,8 +1644,9 @@ def box_violin_plot(
     display preferences, including support for axis limits, label customization,
     and rotated layouts.
 
-    Figures are saved only when ``image_filename`` is provided along with at
-    least one of ``image_path_png`` or ``image_path_svg``.
+    Figures are saved only when ``image_filename`` is provided. If it includes
+    an extension the figure is saved verbatim with no directory required;
+    otherwise it is used as a stem with ``image_path_png`` / ``image_path_svg``.
 
     Parameters:
     -----------
@@ -1629,10 +1677,12 @@ def box_violin_plot(
         will not be saved as SVG.
 
     image_filename : str, optional
-        Base filename (without extension) used when saving figures. No files
-        are saved if this is not provided. For individual plots, the metric
-        name and plot type are appended to this base. For subplot grids, the
-        plot type is appended.
+        Filename used when saving figures. No files are saved if this is not
+        provided. May be a bare stem (legacy: requires ``image_path_png`` /
+        ``image_path_svg``) or a full path with extension (saved verbatim, no
+        directory needed). For individual plots the metric name and plot type
+        are appended to the stem; for the subplot grid the plot type is
+        appended. The extension, if present, is preserved.
 
     show_legend : bool, optional (default=True)
         Whether to display the legend on the plots.
@@ -1718,8 +1768,8 @@ def box_violin_plot(
           list of two numbers.
         - If ``plot_type`` is not one of "boxplot", "violinplot", "box",
           or "violin".
-        - If ``image_filename`` is provided but neither ``image_path_png`` nor
-          ``image_path_svg`` is specified.
+        - If ``image_filename`` is provided without an extension and neither
+          ``image_path_png`` nor ``image_path_svg`` is specified.
 
     Notes:
     ------
@@ -1734,6 +1784,8 @@ def box_violin_plot(
       (or ``x_order`` / ``y_order`` depending on orientation).
     - ``suptitle`` applies only to the subplot grid. Individual plots use
       per-subplot titles only.
+    - Tick labels on the numeric (metric) axis are formatted with thousands
+      separators. The categorical comparison axis is left unformatted.
     """
 
     # Coerce metrics_comp string to list
@@ -1796,11 +1848,15 @@ def box_violin_plot(
         )
 
     # Validate image_filename usage
-    if image_filename is not None and not (image_path_png or image_path_svg):
+    if (
+        image_filename is not None
+        and not os.path.splitext(image_filename)[1]
+        and not (image_path_png or image_path_svg)
+    ):
         raise ValueError(
-            "``image_filename`` was provided but neither ``image_path_png`` "
-            "nor ``image_path_svg`` was specified. Provide at least one output "
-            "path to save figures."
+            "``image_filename`` was provided without a file extension and "
+            "neither ``image_path_png`` nor ``image_path_svg`` was specified. "
+            "Provide an extension (e.g. 'plot.png') or at least one output path."
         )
 
     total_plots = len(metrics_list) * len(metrics_comp)
@@ -1893,6 +1949,7 @@ def box_violin_plot(
                 )
                 ax.tick_params(axis="x", rotation=xlabel_rot)
                 ax.tick_params(axis="both", labelsize=tick_fontsize)
+                _apply_thousands(ax, axis="x" if rotate_plot else "y")
 
                 if xlim:
                     ax.set_xlim(xlim)
@@ -1911,14 +1968,20 @@ def box_violin_plot(
                         .replace(")", "")
                         .replace("/", "_per_")
                     )
+                    combo = f"{safe_met_list}_by_{met_comp}_{plot_type}"
+                    if_dir, if_base = os.path.split(image_filename)
+                    if_stem, if_ext = os.path.splitext(if_base)
+                    per_combo_stem = f"{if_stem}_{combo}"
+                    per_combo_name = (
+                        os.path.join(if_dir, f"{per_combo_stem}{if_ext}")
+                        if if_ext
+                        else per_combo_stem
+                    )
                     _save_figure(
                         fig=fig,
                         image_path_png=image_path_png,
                         image_path_svg=image_path_svg,
-                        filename=(
-                            f"{image_filename}_{safe_met_list}"
-                            f"_by_{met_comp}_{plot_type}"
-                        ),
+                        image_filename=per_combo_name,
                     )
 
                 plt.show()
@@ -1995,6 +2058,7 @@ def box_violin_plot(
                 )
                 ax.tick_params(axis="x", rotation=xlabel_rot)
                 ax.tick_params(axis="both", labelsize=tick_fontsize)
+                _apply_thousands(ax, axis="x" if rotate_plot else "y")
 
                 if xlim:
                     ax.set_xlim(xlim)
@@ -2012,14 +2076,21 @@ def box_violin_plot(
         plt.tight_layout()
 
         if image_filename is not None:
+            if_dir, if_base = os.path.split(image_filename)
+            if_stem, if_ext = os.path.splitext(if_base)
+            grid_stem = f"{if_stem}_{plot_type}"
+            grid_name = (
+                os.path.join(if_dir, f"{grid_stem}{if_ext}") if if_ext else grid_stem
+            )
             _save_figure(
                 fig=fig,
                 image_path_png=image_path_png,
                 image_path_svg=image_path_svg,
-                filename=f"{image_filename}_{plot_type}",
+                image_filename=grid_name,
             )
 
         plt.show()
+
 
 ################################################################################
 ########################## Multi-Purpose Scatter Plots #########################
@@ -2037,6 +2108,7 @@ def scatter_fit_plot(
     max_cols: int = 4,
     image_path_png: Optional[str] = None,
     image_path_svg: Optional[str] = None,
+    image_filename: Optional[str] = None,
     save_plots: Optional[str] = None,
     show_legend: bool = True,
     legend_loc: str = "best",
@@ -2105,9 +2177,19 @@ def scatter_fit_plot(
     image_path_svg : str, optional
         Directory path to save SVG images of the scatter plots.
 
+    image_filename : str, optional
+        Destination for saved plots. May be a bare stem (legacy: requires
+        ``image_path_png`` / ``image_path_svg``) or a full path with extension
+        (saved verbatim, no directory needed). For individual saves the
+        ``{x}_vs_{y}`` name is substituted into the stem so each file stays
+        distinct; the subplot grid uses a single name. If None, the auto-
+        generated name is used with the directory paths.
+
     save_plots : str, optional
         Controls which plots to save: "all", "individual", or "subplots".
-        If None, plots will not be saved.
+        If None but an output target (`image_path_png`, `image_path_svg`, or
+        `image_filename`) is provided, defaults to "subplots". If None with no
+        target, plots are not saved.
         - "all": Saves both individual and subplots.
         - "individual": Saves each scatter plot separately with a progress bar
           (powered by `tqdm`) to track saving progress.
@@ -2219,8 +2301,8 @@ def scatter_fit_plot(
         If `save_plots` is not one of [None, "all", "individual", "subplots"].
 
     ValueError
-        If `save_plots` is set without specifying either `image_path_png` or
-        `image_path_svg`.
+        If `save_plots` is set (or a save target is implied) without any of
+        `image_path_png`, `image_path_svg`, or `image_filename`.
 
     ValueError
         If `rotate_plot` is not a boolean value.
@@ -2330,9 +2412,16 @@ def scatter_fit_plot(
             "'individual', 'subplots', or None."
         )
 
-    # Check if save_plots is set without image paths
-    if save_plots and not (image_path_png or image_path_svg):
-        raise ValueError("To save plots, specify `image_path_png` or `image_path_svg`.")
+    # If an output target is supplied but save_plots wasn't, default to subplots
+    if save_plots is None and (image_path_png or image_path_svg or image_filename):
+        save_plots = "subplots"
+
+    # Check if save_plots is set without any output target
+    if save_plots and not (image_path_png or image_path_svg or image_filename):
+        raise ValueError(
+            "To save plots, specify `image_path_png`, `image_path_svg`, "
+            "or `image_filename`."
+        )
 
     # Validate the rotate_plot input
     if not isinstance(rotate_plot, bool):
@@ -2440,6 +2529,7 @@ def scatter_fit_plot(
             )
             ax.tick_params(axis="x", rotation=xlabel_rot)
             ax.tick_params(axis="both", labelsize=tick_fontsize)
+            _apply_thousands(ax)
 
             # Apply xlim and ylim if provided
             if xlim:
@@ -2523,6 +2613,7 @@ def scatter_fit_plot(
                 )
                 ax.tick_params(axis="x", rotation=xlabel_rot)
                 ax.tick_params(axis="both", labelsize=tick_fontsize)
+                _apply_thousands(ax)
 
                 # Apply xlim and ylim if provided
                 if xlim:
@@ -2558,6 +2649,8 @@ def scatter_fit_plot(
                 )
 
                 if add_best_fit_line:
+                    x_data = df[x_var] if not rotate_plot else df[y_var]
+                    y_data = df[y_var] if not rotate_plot else df[x_var]
                     _add_best_fit(
                         ax=ax,
                         x=x_data,
@@ -2574,25 +2667,20 @@ def scatter_fit_plot(
                 )
                 ax.tick_params(axis="x", rotation=xlabel_rot)
                 ax.tick_params(axis="both", labelsize=tick_fontsize)
+                _apply_thousands(ax)
 
                 safe_x_var = x_var.replace(" ", "_").replace("/", "_per_")
                 safe_y_var = y_var.replace(" ", "_").replace("/", "_per_")
-                if image_path_png:
-                    fig_individual.savefig(
-                        os.path.join(
-                            image_path_png,
-                            f"scatter_{safe_x_var}_vs_{safe_y_var}.png",
-                        ),
-                        bbox_inches="tight",
-                    )
-                if image_path_svg:
-                    fig_individual.savefig(
-                        os.path.join(
-                            image_path_svg,
-                            f"scatter_{safe_x_var}_vs_{safe_y_var}.svg",
-                        ),
-                        bbox_inches="tight",
-                    )
+                _save_figure(
+                    fig=fig_individual,
+                    image_path_png=image_path_png,
+                    image_path_svg=image_path_svg,
+                    image_filename=_resolve_save_name(
+                        image_filename,
+                        f"scatter_{safe_x_var}_vs_{safe_y_var}",
+                        multi=True,
+                    ),
+                )
                 plt.close(fig_individual)  # Clear memory
                 pbar.update(1)  # Update progress bar
 
@@ -2646,24 +2734,19 @@ def scatter_fit_plot(
                 )
                 ax.tick_params(axis="x", rotation=xlabel_rot)
                 ax.tick_params(axis="both", labelsize=tick_fontsize)
+                _apply_thousands(ax)
             else:
                 ax.axis("off")  # Turn off unused axes
 
         plt.tight_layout()
 
         # Save the subplots without a progress bar
-        subplots_filename_png = "scatter_plots_subplots.png"
-        subplots_filename_svg = "scatter_plots_subplots.svg"
-        if image_path_png:
-            fig_grid.savefig(
-                os.path.join(image_path_png, subplots_filename_png),
-                bbox_inches="tight",
-            )
-        if image_path_svg:
-            fig_grid.savefig(
-                os.path.join(image_path_svg, subplots_filename_svg),
-                bbox_inches="tight",
-            )
+        _save_figure(
+            fig=fig_grid,
+            image_path_png=image_path_png,
+            image_path_svg=image_path_svg,
+            image_filename=_resolve_save_name(image_filename, "scatter_plots_subplots"),
+        )
 
         plt.close(fig_grid)  # Clear memory
 
@@ -2671,6 +2754,7 @@ def scatter_fit_plot(
 ################################################################################
 ######################### Correlation Matrices #################################
 ################################################################################
+
 
 def flex_corr_matrix(
     df: pd.DataFrame,
@@ -2941,12 +3025,15 @@ def flex_corr_matrix(
         )
 
     # Validate paths are specified if image_filename is provided
-    if image_filename is not None and not (image_path_png or image_path_svg):
+    if (
+        image_filename is not None
+        and not os.path.splitext(image_filename)[1]
+        and not (image_path_png or image_path_svg)
+    ):
         raise ValueError(
-            "You must specify `image_path_png` or `image_path_svg` "
-            "when `image_filename` is provided."
+            "You must specify `image_path_png` or `image_path_svg` when "
+            "`image_filename` has no file extension."
         )
-
     # Filter DataFrame if cols are specified
     if cols is not None:
         df = df[cols]
@@ -3044,7 +3131,9 @@ def flex_corr_matrix(
                     elif not pd.isna(p) and p >= significance_level:
                         annot_data.loc[col_i, col_j] = ""
                     else:
-                        annot_data.loc[col_i, col_j] = f"{corr_matrix.loc[col_i, col_j]:.2f}"
+                        annot_data.loc[col_i, col_j] = (
+                            f"{corr_matrix.loc[col_i, col_j]:.2f}"
+                        )
             annot_arg = annot_data
             fmt_arg = ""
     else:
@@ -3194,6 +3283,7 @@ def flex_corr_matrix(
             image_path_png=image_path_png,
             image_path_svg=image_path_svg,
             filename=image_filename,
+            image_filename=image_filename,
         )
 
     # Legacy save_plots path — derives filename from title
@@ -3205,6 +3295,7 @@ def flex_corr_matrix(
             image_path_png=image_path_png,
             image_path_svg=image_path_svg,
             filename=safe_title,
+            image_filename=image_filename,
         )
 
     plt.show()
@@ -3250,8 +3341,9 @@ def data_doctor(
     specified.
 
     Plots are displayed by default. If `image_filename` is provided, the figure
-    is saved as PNG and/or SVG depending on which output directories are supplied
-    via `image_path_png` and/or `image_path_svg`.
+    is saved: with an extension it is written verbatim to that path (no
+    directory needed); without one it is combined with `image_path_png` and/or
+    `image_path_svg`.
 
     Parameters
     ----------
@@ -3328,16 +3420,18 @@ def data_doctor(
     box_violin_ylim : tuple of (float, float), optional
         Limits for the boxplot or violin plot y-axis.
 
-    image_filename : str, optional
-        Base filename (without extension) used when saving plots. If provided,
-        the figure is saved to disk using the directories specified by
-        `image_path_png` and/or `image_path_svg`.
-
     image_path_png : str, optional
         Directory path used to save a PNG version of the figure.
 
     image_path_svg : str, optional
         Directory path used to save an SVG version of the figure.
+
+    image_filename : str, optional
+        Filename used when saving the figure. May be a full path with extension
+        (saved verbatim, no directory required) or a bare stem combined with
+        `image_path_png` / `image_path_svg`. The feature name, transformation,
+        plot types, and cutoff flag are encoded into the auto-generated name
+        when a stem (or no name) is used. If None, the figure is not saved.
 
     apply_as_new_col_to_df : bool, optional (default=False)
         Whether to add the transformed feature back to the DataFrame as a new
@@ -3383,8 +3477,8 @@ def data_doctor(
         If an invalid `plot_type` or `box_violin` option is provided.
 
     ValueError
-        If `image_filename` is provided but neither `image_path_png` nor
-        `image_path_svg` is specified.
+        If `image_filename` is provided without an extension and neither
+        `image_path_png` nor `image_path_svg` is specified.
 
     ValueError
         If the length of the transformed data does not match the original
@@ -3394,11 +3488,13 @@ def data_doctor(
     -----
     - Saving is filename-driven: plots are written only when
     `image_filename` is provided.
-    - File extensions are handled internally; users supply directory paths
-    and a filename stem only.
+    - A full-path `image_filename` (with extension) is saved verbatim with no
+    directory required; a bare stem is combined with the provided directories.
     - Output filenames encode the feature name, transformation, plot types,
     and whether cutoffs were applied.
     - Cutoff values, when used, are displayed beneath the plots for clarity.
+    - The histogram count (y) axis uses thousands separators. The x-axis keeps
+    scientific notation for values at or above 100,000.
     """
 
     # Suppress warnings for division by zero, or invalid values in subtract
@@ -3847,6 +3943,9 @@ def data_doctor(
                 ax.set_xlabel(f"{feature_name}", fontsize=label_fontsize)
                 ax.set_ylabel("Count", fontsize=label_fontsize)
                 ax.tick_params(axis="both", labelsize=tick_fontsize)
+                ax.yaxis.set_major_formatter(
+                    plt.FuncFormatter(lambda v, _: f"{v:,.0f}")
+                )
                 if xlim:
                     ax.set_xlim(xlim)
                 if hist_ylim:
@@ -3936,8 +4035,9 @@ def data_doctor(
                         va="center",
                         transform=ax.transAxes,
                     )
+                    kind_label = "Boxplot" if box_violin == "boxplot" else "Violinplot"
                     ax.set_title(
-                        f"{'Boxplot' if box_violin == 'boxplot' else 'Violinplot'}: {feature_name} (Scale: {scale_conversion})",
+                        f"{kind_label}: {feature_name} " f"(Scale: {scale_conversion})",
                         fontsize=label_fontsize,
                         pad=25,
                     )
@@ -4025,36 +4125,36 @@ def data_doctor(
             f"Valid options are 'boxplot' or 'violinplot'."
         )
 
-    if image_filename and not (image_path_png or image_path_svg):
+    if (
+        image_filename
+        and not os.path.splitext(image_filename)[1]
+        and not (image_path_png or image_path_svg)
+    ):
         raise ValueError(
             "You must provide either 'image_path_png' or 'image_path_svg' "
-            "when 'image_filename' is provided."
+            "when 'image_filename' has no file extension."
         )
 
     # ------------------------------------------------------------------
     # Save figure (optional)
     # ------------------------------------------------------------------
-    if image_filename and (image_path_png or image_path_svg):
+    if image_path_png or image_path_svg or image_filename:
         # Adjust plot_type for custom labeling of boxplot or violinplot
         adjusted_plot_type = [
             box_violin if ptype == "box_violin" else ptype for ptype in plot_type
         ]
-
         plot_type_str = "_".join(adjusted_plot_type)
-
         cutoff_str = "_cutoff" if apply_cutoff else ""
-
-        filename = (
+        auto_name = (
             f"{feature_name}_"
             f"{scale_conversion if scale_conversion else 'original'}_"
             f"{plot_type_str}{cutoff_str}"
         )
-
         _save_figure(
             fig=fig,
             image_path_png=image_path_png,
             image_path_svg=image_path_svg,
-            filename=filename,
+            image_filename=_resolve_save_name(image_filename, auto_name),
         )
 
 
@@ -4083,6 +4183,7 @@ def outcome_crosstab_plot(
     save_plots: bool = False,
     image_path_png: Optional[str] = None,
     image_path_svg: Optional[str] = None,
+    image_filename: Optional[str] = None,
     string: Optional[str] = None,
 ) -> None:
     """
@@ -4108,11 +4209,36 @@ def outcome_crosstab_plot(
     - normalize: bool, False for raw counts, True for normalized proportions.
     - show_value_counts: bool, append counts or percentages to legend entries.
     - color_schema: None, list, or dict for color customization.
-    - save_plots: bool, save figures if True.
-    - image_path_png, image_path_svg: str paths for saving.
-    - string: base filename for saving (sanitized).
+    - save_plots: bool, save via the legacy `string`/directory scheme if True.
+      Ignored when `image_filename` is given.
+    - image_path_png, image_path_svg: str, directory paths for saving. Required
+      with `save_plots`, or with a bare-stem `image_filename`.
+    - image_filename: str, optional destination. With an extension it is saved
+      verbatim (no directory needed); without one it is combined with
+      `image_path_png` / `image_path_svg`. Takes precedence over `save_plots`.
+    - string: base filename (sanitized: spaces to underscores, colons removed,
+      lowercased) for the legacy `save_plots` path. Defaults to
+      "crosstab_plot".
+
+    Raises:
+        - ValueError: if `image_filename` is provided without an extension and
+        neither `image_path_png` nor `image_path_svg` is specified.
+
+    Notes:
+        - The count (y) axis and legend counts use thousands separators; the
+        normalized axis and legend use whole-number percentages.
     """
     n_vars = len(list_name)
+
+    if (
+        image_filename is not None
+        and not os.path.splitext(image_filename)[1]
+        and not (image_path_png or image_path_svg)
+    ):
+        raise ValueError(
+            "You must specify `image_path_png` or `image_path_svg` when "
+            "`image_filename` has no file extension."
+        )
 
     # Determine grid size
     if n_rows is None and n_cols is None:
@@ -4134,6 +4260,7 @@ def outcome_crosstab_plot(
         # Compute crosstab
         if not normalize:
             ylabel = "Count"
+            ax.yaxis.set_major_formatter(plt.FuncFormatter(lambda v, _: f"{v:,.0f}"))
             ctab = pd.crosstab(df[outcome], df[item])
         else:
             ylabel = "Percentage"
@@ -4172,7 +4299,7 @@ def outcome_crosstab_plot(
             if not normalize:
                 counts = df[item].value_counts()
                 labels = [
-                    f"{lbl} (n={counts.get(col, 0)})"
+                    f"{lbl} (n={counts.get(col, 0):,})"
                     for lbl, col in zip(labels, ctab.columns)
                 ]
             else:
@@ -4201,7 +4328,15 @@ def outcome_crosstab_plot(
     plt.tight_layout(w_pad=w_pad, h_pad=h_pad)
 
     # Save logic
-    if save_plots:
+    if image_filename is not None:
+        _save_figure(
+            fig=fig,
+            image_path_png=image_path_png,
+            image_path_svg=image_path_svg,
+            image_filename=image_filename,
+        )
+
+    elif save_plots:
         base = string or "crosstab_plot"
         safe = base.replace(" ", "_").replace(":", "").lower()
         if image_path_png:
@@ -4340,7 +4475,9 @@ def distribution_gof_plots(
         Directory path for saving SVG output.
 
     image_filename : str, optional
-        Base filename used when saving plots (without extension).
+        Filename used when saving. With an extension it is saved verbatim (no
+        directory required); without one it is combined with `image_path_png` /
+        `image_path_svg`.
 
 
     Returns
@@ -4357,8 +4494,8 @@ def distribution_gof_plots(
         If `qq_type="empirical"` is used without valid `reference_data`.
 
     ValueError
-        If `image_filename` is provided but neither `image_path_png` nor
-        `image_path_svg` is specified.
+        If `image_filename` is provided without an extension and neither
+        `image_path_png` nor `image_path_svg` is specified.
 
     Notes
     -----
@@ -4409,11 +4546,11 @@ def distribution_gof_plots(
         if len(reference_data) < 2:
             raise ValueError("reference_data must contain at least 2 observations")
 
-    if image_filename:
+    if image_filename and not os.path.splitext(image_filename)[1]:
         if not (image_path_png or image_path_svg):
             raise ValueError(
                 "You must provide either 'image_path_png' or 'image_path_svg' "
-                "when 'image_filename' is provided."
+                "when 'image_filename' has no file extension."
             )
 
     # -------------------------
@@ -4497,12 +4634,13 @@ def distribution_gof_plots(
     # -------------------------
     plt.tight_layout()
 
-    if image_filename and (image_path_png or image_path_svg):
+    if image_path_png or image_path_svg or image_filename:
         _save_figure(
             fig=fig,
             image_path_png=image_path_png,
             image_path_svg=image_path_svg,
             filename=image_filename,
+            image_filename=image_filename,
         )
 
     plt.show()
@@ -4511,6 +4649,7 @@ def distribution_gof_plots(
 ################################################################################
 ######################### Grouped Distributions Function #######################
 ################################################################################
+
 
 def grouped_distributions(
     df: pd.DataFrame,
@@ -4681,8 +4820,10 @@ def grouped_distributions(
         Directory path to save the SVG image.
 
     image_filename : str, optional
-        Base filename (without extension) for saving the figure. No files
-        are saved if this is not provided.
+        Filename for saving the figure. With an extension it is saved verbatim
+        (no directory required); without one it is combined with
+        ``image_path_png`` / ``image_path_svg``. No files are saved if this is
+        not provided.
 
     Returns
     -------
@@ -4693,8 +4834,8 @@ def grouped_distributions(
     ValueError
         If the ``by`` column is not binary.
         If an invalid ``plot_style`` or ``normalize`` option is provided.
-        If ``image_filename`` is provided but neither ``image_path_png`` nor
-        ``image_path_svg`` is specified.
+        If ``image_filename`` is provided without an extension and neither
+        ``image_path_png`` nor ``image_path_svg`` is specified.
         If the subplot grid is too small for the number of features.
 
     Warnings
@@ -4714,15 +4855,22 @@ def grouped_distributions(
     - To place the legend below a subplot, use
       ``legend_loc="upper center"``, ``legend_bbox_to_anchor=(0.5, -0.15)``,
       and ``legend_ncols=2``.
+    - In count mode (``normalize="count"``), the count (y) axis uses thousands
+      separators. In density/percentage mode the y-axis shows whole-number
+      percentages when ``pct_format=True``.
     """
 
     # ------------------------------------------------------------------
     # Validation
     # ------------------------------------------------------------------
-    if image_filename and not (image_path_png or image_path_svg):
+    if (
+        image_filename
+        and not os.path.splitext(image_filename)[1]
+        and not (image_path_png or image_path_svg)
+    ):
         raise ValueError(
             "You must provide either 'image_path_png' or 'image_path_svg' "
-            "when 'image_filename' is provided."
+            "when 'image_filename' has no file extension."
         )
 
     if by not in df.columns:
@@ -4730,9 +4878,7 @@ def grouped_distributions(
 
     unique_vals = df[by].dropna().unique()
     if len(unique_vals) != 2:
-        raise ValueError(
-            f"Column '{by}' must be binary. Found values: {unique_vals}"
-        )
+        raise ValueError(f"Column '{by}' must be binary. Found values: {unique_vals}")
 
     if plot_style not in {"hist", "density"}:
         raise ValueError("plot_style must be 'hist' or 'density'.")
@@ -4868,6 +5014,7 @@ def grouped_distributions(
             )
         else:
             ax.set_ylabel("Count", fontsize=label_fontsize)
+            ax.yaxis.set_major_formatter(FuncFormatter(lambda v, _: f"{v:,.0f}"))
 
         ax.tick_params(axis="both", labelsize=tick_fontsize)
 
@@ -4897,9 +5044,7 @@ def grouped_distributions(
         # Percentage formatter
         # -----------------------
         if pct_format and (plot_style == "density" or normalize == "density"):
-            ax.yaxis.set_major_formatter(
-                FuncFormatter(lambda x, _: f"{x * 100:.0f}%")
-            )
+            ax.yaxis.set_major_formatter(FuncFormatter(lambda x, _: f"{x * 100:.0f}%"))
 
         # -----------------------
         # Axis limits
@@ -4923,12 +5068,13 @@ def grouped_distributions(
     # ------------------------------------------------------------------
     # Save
     # ------------------------------------------------------------------
-    if image_path_png or image_path_svg:
+    if image_path_png or image_path_svg or image_filename:
         _save_figure(
             fig=fig,
             image_path_png=image_path_png,
             image_path_svg=image_path_svg,
             filename=image_filename,
+            image_filename=image_filename,
             bbox_inches=bbox_inches,
             dpi=dpi,
         )

--- a/unittests/test_plot_utils.py
+++ b/unittests/test_plot_utils.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 import pandas as pd
 import scipy.stats as stats
@@ -8,6 +9,8 @@ import matplotlib.pyplot as plt
 
 from eda_toolkit._plot_utils import (
     _save_figure,
+    _resolve_save_name,
+    _apply_thousands,
     _add_best_fit,
     _get_label,
     _get_palette,
@@ -57,6 +60,104 @@ def test_save_figure_png_and_svg(fig_ax, tmp_path):
         )
 
         assert mock_save.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# _save_figure: full-path saving, alias, auto-mkdir (refactor)
+# ---------------------------------------------------------------------------
+
+
+def test_save_figure_full_path_no_directory_arg(fig_ax, tmp_path):
+    """image_filename with an extension saves verbatim, no image_path_* needed."""
+    fig, _ = fig_ax
+    target = tmp_path / "verbatim.png"
+    _save_figure(fig=fig, image_filename=str(target))
+    assert target.exists()
+
+
+def test_save_figure_legacy_filename_alias(fig_ax, tmp_path):
+    """The old filename= keyword still works via the alias."""
+    fig, _ = fig_ax
+    _save_figure(fig=fig, image_path_png=str(tmp_path), filename="legacy")
+    assert (tmp_path / "legacy.png").exists()
+
+
+def test_save_figure_legacy_dir_plus_stem(fig_ax, tmp_path):
+    """Extensionless image_filename + directory writes {dir}/{stem}.png|.svg."""
+    fig, _ = fig_ax
+    _save_figure(
+        fig=fig,
+        image_path_png=str(tmp_path),
+        image_path_svg=str(tmp_path),
+        image_filename="stem",
+    )
+    assert (tmp_path / "stem.png").exists()
+    assert (tmp_path / "stem.svg").exists()
+
+
+def test_save_figure_creates_missing_directories(fig_ax, tmp_path):
+    """Nested output directories are created automatically."""
+    fig, _ = fig_ax
+    target = tmp_path / "a" / "b" / "c" / "nested.png"
+    _save_figure(fig=fig, image_filename=str(target))
+    assert target.exists()
+
+
+# ---------------------------------------------------------------------------
+# _resolve_save_name: single vs multi naming (refactor)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "user_filename, multi, expected",
+    [
+        ("", False, "auto"),
+        (None, False, "auto"),
+        ("myname", False, os.path.join("myname", "auto")),
+        ("out/dir/", False, os.path.join("out/dir/", "auto")),
+        ("dir/file.png", False, "dir/file.png"),
+        ("dir/file.png", True, os.path.join("dir", "auto.png")),
+        ("file.png", True, "auto.png"),
+        ("file.svg", False, "file.svg"),
+    ],
+)
+def test_resolve_save_name(user_filename, multi, expected):
+    assert _resolve_save_name(user_filename, "auto", multi=multi) == expected
+
+
+# ---------------------------------------------------------------------------
+# _apply_thousands: comma grouping on numeric axes (refactor)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_thousands_commas_large_numbers(fig_ax):
+    fig, ax = fig_ax
+    ax.plot([0, 250000, 1400000], [1, 2, 3])
+    _apply_thousands(ax, axis="x")
+    fig.canvas.draw()
+    labels = [t.get_text() for t in ax.get_xticklabels()]
+    assert any("," in lbl for lbl in labels)
+
+
+def test_apply_thousands_preserves_decimals(fig_ax):
+    fig, ax = fig_ax
+    ax.plot([0.0, 0.25, 0.5, 0.75], [1, 2, 3, 4])
+    _apply_thousands(ax, axis="x")
+    fig.canvas.draw()
+    labels = [t.get_text() for t in ax.get_xticklabels() if t.get_text()]
+    assert any("." in lbl for lbl in labels)
+    assert not any("," in lbl for lbl in labels)
+
+
+def test_apply_thousands_axis_x_only_leaves_y_untouched(fig_ax):
+    fig, ax = fig_ax
+    ax.plot([0, 1000000], [0, 1000000])
+    _apply_thousands(ax, axis="x")
+    fig.canvas.draw()
+    x_labels = [t.get_text() for t in ax.get_xticklabels()]
+    y_labels = [t.get_text() for t in ax.get_yticklabels()]
+    assert any("," in lbl for lbl in x_labels)
+    assert not any("," in lbl for lbl in y_labels)
 
 
 def test_add_best_fit_with_legend(fig_ax):

--- a/unittests/test_plot_utils.py
+++ b/unittests/test_plot_utils.py
@@ -43,9 +43,11 @@ def test_save_figure_no_filename_noop(fig_ax):
     _save_figure(fig=fig)
 
 
-def test_save_figure_no_paths_noop(fig_ax):
+def test_save_figure_bare_stem_no_dir_raises(fig_ax):
+    """Bare stem (no extension) with no output directory must raise, not silently no-op."""
     fig, _ = fig_ax
-    _save_figure(fig=fig, filename="test")
+    with pytest.raises(ValueError, match="no.*file extension"):
+        _save_figure(fig=fig, filename="test")
 
 
 def test_save_figure_png_and_svg(fig_ax, tmp_path):

--- a/unittests/test_plots.py
+++ b/unittests/test_plots.py
@@ -44,6 +44,7 @@ def sample_corr_dataframe():
         }
     )
 
+
 @pytest.fixture
 def sample_scatter_dataframe():
     np.random.seed(42)
@@ -119,10 +120,12 @@ def gof_df():
         }
     )
 
+
 @pytest.fixture
 def reference_data():
     rng = np.random.default_rng(999)
     return rng.normal(size=200)
+
 
 @pytest.fixture
 def sample_corr_dataframe_large():
@@ -133,9 +136,9 @@ def sample_corr_dataframe_large():
     return pd.DataFrame(
         {
             "A": x1,
-            "B": x1 * 0.9 + np.random.randn(n) * 0.1,   # strongly correlated
-            "C": np.random.randn(n),                        # uncorrelated
-            "D": x1 * -0.8 + np.random.randn(n) * 0.2,   # strongly negatively correlated
+            "B": x1 * 0.9 + np.random.randn(n) * 0.1,  # strongly correlated
+            "C": np.random.randn(n),  # uncorrelated
+            "D": x1 * -0.8 + np.random.randn(n) * 0.2,  # strongly negatively correlated
         }
     )
 
@@ -798,42 +801,43 @@ def test_flex_corr_matrix_save_plot(sample_corr_dataframe, tmp_path):
 # ------------------------------------------------------------------
 # Basic smoke tests
 # ------------------------------------------------------------------
- 
+
+
 def test_flex_corr_matrix_no_colorbar(sample_corr_dataframe):
     flex_corr_matrix(sample_corr_dataframe, show_colorbar=False)
- 
- 
+
+
 def test_flex_corr_matrix_full_matrix(sample_corr_dataframe):
     flex_corr_matrix(sample_corr_dataframe, triangular=False)
- 
- 
+
+
 def test_flex_corr_matrix_with_title(sample_corr_dataframe):
     flex_corr_matrix(sample_corr_dataframe, title="Test Title")
- 
- 
+
+
 def test_flex_corr_matrix_custom_figsize(sample_corr_dataframe):
     flex_corr_matrix(sample_corr_dataframe, figsize=(6, 6))
- 
- 
+
+
 def test_flex_corr_matrix_label_names(sample_corr_dataframe):
     flex_corr_matrix(
         sample_corr_dataframe,
         label_names={"Feature1": "F1", "Feature2": "F2", "Feature3": "F3"},
     )
- 
- 
+
+
 def test_flex_corr_matrix_no_annot(sample_corr_dataframe):
     flex_corr_matrix(sample_corr_dataframe, annot=False)
- 
- 
+
+
 def test_flex_corr_matrix_custom_cmap(sample_corr_dataframe):
     flex_corr_matrix(sample_corr_dataframe, cmap="viridis")
- 
- 
+
+
 def test_flex_corr_matrix_xlabel_rotation(sample_corr_dataframe):
     flex_corr_matrix(sample_corr_dataframe, xlabel_rot=90)
- 
- 
+
+
 def test_flex_corr_matrix_image_filename(sample_corr_dataframe, tmp_path):
     flex_corr_matrix(
         sample_corr_dataframe,
@@ -841,8 +845,8 @@ def test_flex_corr_matrix_image_filename(sample_corr_dataframe, tmp_path):
         image_path_png=str(tmp_path),
     )
     assert any(f.endswith(".png") for f in os.listdir(tmp_path))
- 
- 
+
+
 def test_flex_corr_matrix_image_filename_svg(sample_corr_dataframe, tmp_path):
     flex_corr_matrix(
         sample_corr_dataframe,
@@ -850,45 +854,47 @@ def test_flex_corr_matrix_image_filename_svg(sample_corr_dataframe, tmp_path):
         image_path_svg=str(tmp_path),
     )
     assert any(f.endswith(".svg") for f in os.listdir(tmp_path))
- 
- 
+
+
 # ------------------------------------------------------------------
 # corr_method
 # ------------------------------------------------------------------
- 
+
+
 def test_flex_corr_matrix_spearman(sample_corr_dataframe):
     flex_corr_matrix(sample_corr_dataframe, corr_method="spearman")
- 
- 
+
+
 def test_flex_corr_matrix_kendall(sample_corr_dataframe):
     flex_corr_matrix(sample_corr_dataframe, corr_method="kendall")
- 
- 
+
+
 def test_flex_corr_matrix_invalid_corr_method(sample_corr_dataframe):
     with pytest.raises(ValueError, match="Invalid `corr_method`"):
         flex_corr_matrix(sample_corr_dataframe, corr_method="invalid")
- 
- 
+
+
 # ------------------------------------------------------------------
 # Significance overlay
 # ------------------------------------------------------------------
- 
+
+
 def test_flex_corr_matrix_show_significance_stars(sample_corr_dataframe_large):
     flex_corr_matrix(
         sample_corr_dataframe_large,
         show_significance=True,
         significance_method="stars",
     )
- 
- 
+
+
 def test_flex_corr_matrix_show_significance_mask(sample_corr_dataframe_large):
     flex_corr_matrix(
         sample_corr_dataframe_large,
         show_significance=True,
         significance_method="mask",
     )
- 
- 
+
+
 def test_flex_corr_matrix_invalid_significance_method(sample_corr_dataframe):
     with pytest.raises(ValueError, match="Invalid `significance_method`"):
         flex_corr_matrix(
@@ -896,8 +902,8 @@ def test_flex_corr_matrix_invalid_significance_method(sample_corr_dataframe):
             show_significance=True,
             significance_method="pvalues",
         )
- 
- 
+
+
 def test_flex_corr_matrix_significance_level_strict(sample_corr_dataframe_large):
     flex_corr_matrix(
         sample_corr_dataframe_large,
@@ -905,8 +911,8 @@ def test_flex_corr_matrix_significance_level_strict(sample_corr_dataframe_large)
         significance_level=0.01,
         significance_method="stars",
     )
- 
- 
+
+
 def test_flex_corr_matrix_significance_legend_x(sample_corr_dataframe_large):
     flex_corr_matrix(
         sample_corr_dataframe_large,
@@ -914,8 +920,8 @@ def test_flex_corr_matrix_significance_legend_x(sample_corr_dataframe_large):
         significance_method="stars",
         significance_legend_x=0.3,
     )
- 
- 
+
+
 def test_flex_corr_matrix_spearman_significance(sample_corr_dataframe_large):
     flex_corr_matrix(
         sample_corr_dataframe_large,
@@ -923,8 +929,8 @@ def test_flex_corr_matrix_spearman_significance(sample_corr_dataframe_large):
         show_significance=True,
         significance_method="stars",
     )
- 
- 
+
+
 def test_flex_corr_matrix_kendall_significance(sample_corr_dataframe_large):
     flex_corr_matrix(
         sample_corr_dataframe_large,
@@ -932,26 +938,27 @@ def test_flex_corr_matrix_kendall_significance(sample_corr_dataframe_large):
         show_significance=True,
         significance_method="mask",
     )
- 
- 
+
+
 # ------------------------------------------------------------------
 # filter_significance
 # ------------------------------------------------------------------
- 
+
+
 def test_flex_corr_matrix_filter_significance(sample_corr_dataframe_large):
     flex_corr_matrix(
         sample_corr_dataframe_large,
         filter_significance=0.05,
     )
- 
- 
+
+
 def test_flex_corr_matrix_filter_significance_strict(sample_corr_dataframe_large):
     flex_corr_matrix(
         sample_corr_dataframe_large,
         filter_significance=0.001,
     )
- 
- 
+
+
 def test_flex_corr_matrix_filter_significance_auto_enables_show_significance(
     sample_corr_dataframe_large,
 ):
@@ -964,62 +971,70 @@ def test_flex_corr_matrix_filter_significance_auto_enables_show_significance(
         )
     except Exception as e:
         pytest.fail(f"filter_significance failed to auto-enable significance: {e}")
- 
- 
+
+
 def test_flex_corr_matrix_filter_significance_invalid(sample_corr_dataframe):
     with pytest.raises(ValueError, match="`filter_significance`"):
         flex_corr_matrix(
             sample_corr_dataframe,
             filter_significance=-0.05,
         )
- 
- 
+
+
 def test_flex_corr_matrix_filter_significance_invalid_type(sample_corr_dataframe):
     with pytest.raises((ValueError, TypeError)):
         flex_corr_matrix(
             sample_corr_dataframe,
             filter_significance="0.05",
         )
- 
- 
+
+
 # ------------------------------------------------------------------
 # Validation errors
 # ------------------------------------------------------------------
- 
+
+
 def test_flex_corr_matrix_invalid_annot(sample_corr_dataframe):
     with pytest.raises(ValueError, match="Invalid value for `annot`"):
         flex_corr_matrix(sample_corr_dataframe, annot="yes")
- 
- 
+
+
 def test_flex_corr_matrix_invalid_save_plots(sample_corr_dataframe):
     with pytest.raises(ValueError, match="Invalid `save_plots`"):
         flex_corr_matrix(sample_corr_dataframe, save_plots="yes")
- 
- 
+
+
 def test_flex_corr_matrix_invalid_triangular(sample_corr_dataframe):
     with pytest.raises(ValueError, match="Invalid `triangular`"):
         flex_corr_matrix(sample_corr_dataframe, triangular="yes")
- 
- 
+
+
 def test_flex_corr_matrix_invalid_cols_type(sample_corr_dataframe):
     with pytest.raises(ValueError, match="`cols` parameter must be a list"):
         flex_corr_matrix(sample_corr_dataframe, cols="Feature1")
- 
- 
+
+
 def test_flex_corr_matrix_save_plots_without_path(sample_corr_dataframe):
-    with pytest.raises(ValueError, match="image_path_png.*image_path_svg|image_path_svg.*image_path_png|specify"):
+    with pytest.raises(
+        ValueError,
+        match="image_path_png.*image_path_svg|image_path_svg.*image_path_png|specify",
+    ):
         flex_corr_matrix(sample_corr_dataframe, save_plots=True)
- 
- 
+
+
 def test_flex_corr_matrix_image_filename_without_path(sample_corr_dataframe):
-    with pytest.raises(ValueError, match="image_path_png.*image_path_svg|image_path_svg.*image_path_png|specify"):
+    with pytest.raises(
+        ValueError,
+        match="image_path_png.*image_path_svg|image_path_svg.*image_path_png|specify",
+    ):
         flex_corr_matrix(sample_corr_dataframe, image_filename="test")
- 
- 
+
+
 ################################################################################
 # Near-zero artifact
 ################################################################################
- 
+
+
 def test_flex_corr_matrix_no_negative_zero(sample_corr_dataframe_large, tmp_path):
     """Verify that near-zero values don't produce -0.00 in the heatmap."""
     # The fixture has uncorrelated columns — some cells will be near zero
@@ -1156,7 +1171,8 @@ def test_scatter_fit_plot_invalid_rotate_plot(sample_scatter_dataframe):
 
 def test_scatter_fit_plot_save_without_path(sample_scatter_dataframe):
     with pytest.raises(
-        ValueError, match="To save plots, specify `image_path_png` or `image_path_svg`."
+        ValueError,
+        match=r"To save plots, specify `image_path_png`, `image_path_svg`, or `image_filename`\.",
     ):
         scatter_fit_plot(
             sample_scatter_dataframe,
@@ -1399,6 +1415,7 @@ def test_box_violin_plot_invalid_show_plot(sample_box_violin_dataframe):
             show_plot="invalid_option",
         )
 
+
 # Test that `image_filename` without a path raises an error
 def test_box_violin_plot_invalid_save_plots(sample_box_violin_dataframe):
     with pytest.raises(ValueError, match="image_filename"):
@@ -1412,13 +1429,17 @@ def test_box_violin_plot_invalid_save_plots(sample_box_violin_dataframe):
 
 # Test that `image_filename` requires `image_path_png` or `image_path_svg`
 def test_box_violin_plot_missing_image_path(sample_box_violin_dataframe):
-    with pytest.raises(ValueError, match="image_path_png.*image_path_svg|image_path_svg.*image_path_png"):
+    with pytest.raises(
+        ValueError,
+        match="image_path_png.*image_path_svg|image_path_svg.*image_path_png",
+    ):
         box_violin_plot(
             sample_box_violin_dataframe,
             metrics_list=["Metric1"],
             metrics_comp=["Category"],
             image_filename="test_output",  # Should fail since no path is provided
         )
+
 
 # Test that `rotate_plot` must be a boolean value
 def test_box_violin_plot_invalid_rotate_plot(sample_box_violin_dataframe):
@@ -1959,3 +1980,88 @@ def test_distribution_gof_calls_save_figure(gof_df, tmp_path):
         )
 
         mock_save.assert_called_once()
+
+
+# --- single-file functions: full path, no directory, saved verbatim --------
+
+
+def test_flex_corr_matrix_full_path(sample_corr_dataframe, tmp_path):
+    target = tmp_path / "corr.png"
+    flex_corr_matrix(sample_corr_dataframe, image_filename=str(target))
+    assert target.exists()
+
+
+def test_data_doctor_full_path(sample_dataframe_values, tmp_path):
+    target = tmp_path / "dd.png"
+    data_doctor(sample_dataframe_values, "values", image_filename=str(target))
+    assert target.exists()
+
+
+def test_distribution_gof_full_path(gof_df, tmp_path):
+    target = tmp_path / "gof.png"
+    distribution_gof_plots(df=gof_df, var="x", image_filename=str(target))
+    assert target.exists()
+
+
+def test_grouped_distributions_full_path(binary_df, tmp_path):
+    target = tmp_path / "gd.png"
+    grouped_distributions(
+        df=binary_df, features=["x1"], by="group", image_filename=str(target)
+    )
+    assert target.exists()
+
+
+def test_outcome_crosstab_full_path(tmp_path):
+    df = pd.DataFrame(
+        {"sex": ["M", "F", "F", "M", "M", "F"], "outcome": [1, 0, 1, 0, 1, 0]}
+    )
+    target = tmp_path / "oc.png"
+    outcome_crosstab_plot(
+        df=df, list_name=["sex"], outcome="outcome", image_filename=str(target)
+    )
+    assert target.exists()
+    plt.close("all")
+
+
+def test_stacked_crosstab_image_filename_full_path(sample_crosstab_dataframe, tmp_path):
+    stacked_crosstab_plot(
+        df=sample_crosstab_dataframe,
+        col="Category",
+        func_col=["Group"],
+        legend_labels_list=[["X", "Y"]],
+        title=["Full Path"],
+        image_filename=str(tmp_path / "st.png"),
+    )
+    assert any(f.endswith(".png") for f in os.listdir(tmp_path))
+
+
+# --- fan-out functions: full path, extension stays intact (regression) ------
+
+
+def test_box_violin_full_path_fanout(sample_box_violin_dataframe, tmp_path):
+    box_violin_plot(
+        sample_box_violin_dataframe,
+        metrics_list=["Metric1", "Metric2"],
+        metrics_comp=["Category"],
+        show_plot="both",
+        image_filename=str(tmp_path / "bv.png"),
+    )
+    files = os.listdir(tmp_path)
+    assert files, "fan-out produced no files"
+    assert all(f.endswith(".png") for f in files)
+    assert not any(".png_" in f for f in files)
+    plt.close("all")
+
+
+def test_scatter_full_path_fanout(sample_scatter_dataframe, tmp_path):
+    scatter_fit_plot(
+        sample_scatter_dataframe,
+        x_vars=["Feature1"],
+        y_vars=["Feature2"],
+        save_plots="all",
+        image_filename=str(tmp_path / "sc.png"),
+    )
+    files = os.listdir(tmp_path)
+    assert any(f.endswith(".png") for f in files)
+    assert not any(".png_" in f for f in files)
+    plt.close("all")


### PR DESCRIPTION
# Add full-path `image_filename` saving and thousands-separator axis formatting

## Summary

This PR lets every plotting function save figures by passing a single full path through `image_filename` (directory and extension included), with no requirement to also pass `image_path_png` / `image_path_svg`. It also adds comma grouping to numeric axes so large tick values render as `40,000` instead of `40000`.

All changes are additive. Existing call sites that pass `filename=` and/or the `image_path_*` directory arguments keep working byte-for-byte. Nothing in the released API was removed or renamed.

Two files change: `_plot_utils.py` (shared helpers) and `plots.py` (the public plotting functions).

## `_plot_utils.py`

**`_save_figure` rewritten (backward compatible).**

- Added an `image_filename` parameter. The old `filename` parameter is kept as a legacy alias, so the existing call sites that pass `filename=` need no edits (`if image_filename is None: image_filename = filename`).
- If `image_filename` carries an extension, the figure is saved verbatim to that exact path and no directory argument is needed.
- If it has no extension, the old behavior applies: the stem is combined with `image_path_png` / `image_path_svg` to write `{dir}/{stem}.png|.svg`.
- Output directories are now created automatically via `os.makedirs(..., exist_ok=True)` instead of erroring on a missing folder.

**`_resolve_save_name` added.** Centralizes save-name logic for single-file vs fan-out callers. Single-file callers get the user's exact filename. Multi-file callers keep the user's directory and extension but substitute the function's auto-generated stem so the N files stay distinct. A bare name with no extension is treated as a directory (legacy behavior).

**`_apply_thousands(ax, axis="both")` added.** Comma-groups numeric tick labels using `FuncFormatter(lambda v, _: f"{v:,.10g}")`. The `.10g` keeps decimals intact (`0.25` stays `0.25`; only large numbers gain commas). The caller chooses the axis (`"both"`, `"x"`, or `"y"`) because only the caller knows which of its axes is numeric.

Also: added the `matplotlib.ticker as mticker` import, and a docstring typo fix ("Utilitys" to "Utilities").

## `plots.py`

### Full-path `image_filename` support

Across the plotting functions, three independent fixes let a full-path `image_filename` work on its own:

1. **Validation guards relaxed** (6 functions). The early "filename requires a directory" guard now also passes when the filename already has an extension (`and not os.path.splitext(image_filename)[1]`).
2. **Save gates fixed** (6 sites). Gates that read `if image_path_png or image_path_svg:` now also fire on `image_filename` alone, so a full-path filename with no directory no longer silently saves nothing. This includes the `save_plots`-based gates in `scatter_fit_plot` and `outcome_crosstab_plot`.
3. **Fan-out naming fixed.** Functions that append a per-figure suffix (`plot_distributions`, `box_violin_plot`, `scatter_fit_plot`, `stacked_crosstab_plot`) previously concatenated the suffix onto the raw filename, which corrupted the extension (e.g. `plot.png_boxplot`). They now split the extension off first, append the suffix to the stem, then reattach the extension.

`outcome_crosstab_plot` previously had no `image_filename` parameter at all; it was added, routed through `_save_figure`, with the legacy `save_plots` path left intact.

`stacked_crosstab_plot` keeps its own `save_formats` system. `image_filename` was added as an alternate destination that `save_formats` (or the filename's own extension) targets without requiring directories. The legacy `save_formats` + directory filtering is unchanged.

### Axis formatting

- **Continuous numeric axes** use `_apply_thousands`: `scatter_fit_plot` (both axes numeric) and `box_violin_plot` (the metric axis only, selected by `rotate_plot` so categorical group labels are never overwritten).
- **Count axes** use an inline `:,.0f` formatter: `outcome_crosstab_plot` count axis, `grouped_distributions` count branch, and the `data_doctor` histogram count axis. `outcome_crosstab_plot` also commas the `n=` counts in its legend labels.
- **Percent axes** keep their inline `:.0%` formatter.
- `data_doctor` keeps its deliberate scientific-notation handler for very large x-axis values; the thousands helper is intentionally not applied there so it does not override that behavior.
- `distribution_gof_plots` is unchanged on formatting; its QQ/CDF axes are formatted inside their own `_qq_plot` / `_cdf_exceedance_plot` helpers.

### Minor

- `kde_distributions`: deprecation message shortened (cosmetic; still points users to `plot_distributions`).

## Backward compatibility

- Legacy `filename=` call sites work unchanged via the alias.
- Legacy `image_path_png` / `image_path_svg` directory saving is unchanged.
- `stacked_crosstab_plot`'s `save_formats` behavior is unchanged.

Two intentional default-on cosmetic changes to be aware of:

- Numeric count and continuous axes now show thousands separators by default on the affected functions.
- `_save_figure` now creates missing output directories instead of raising.

## Testing

Each change was exercised in a sandbox (matplotlib Agg) confirming: legacy filenames save identically, full-path `image_filename` saves with no directory argument, the previously-crashing suffix-on-extension fan-out cases now save correctly, and the formatters preserve decimals on continuous axes while leaving categorical axis labels untouched.

```text

______ coverage: platform linux, python 3.12.7-final-0_______


Name                                     Stmts   Miss  Cover
------------------------------------------------------------
src/eda_toolkit/__init__.py                 19      2    89%
src/eda_toolkit/_data_manager_utils.py      28      0   100%
src/eda_toolkit/_plot_utils.py             159     23    86%
src/eda_toolkit/art.py                      54      3    94%
src/eda_toolkit/data_manager.py            846     84    90%
src/eda_toolkit/plots.py                  1253    237    81%
------------------------------------------------------------
TOTAL                                     2359    349    85%

```