### PR TITLE
flex_corr_matrix: corr_threshold, return_corr, show_plot

### DIFF
--- a/py_example_notebooks/adult_income_eda.ipynb
+++ b/py_example_notebooks/adult_income_eda.ipynb
@@ -1652,7 +1652,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "corr_tri_sig = flex_corr_matrix(\n",
+    "flex_corr_matrix(\n",
     "    df=df,\n",
     "    cols=df_num.columns.to_list(),\n",
     "    annot=True,\n",
@@ -1671,24 +1671,14 @@
     "    triangular=True,\n",
     "    show_significance=True,\n",
     "    image_filename=\"../images/png_images/correlation_matrix_stat_sig.png\",\n",
-    "    return_corr=True,\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "corr_tri_sig"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Subset by Threshold Cutoff"
+    "### Subset by Threshold Cutoff"
    ]
   },
   {
@@ -1717,6 +1707,77 @@
     "    triangular=True,\n",
     "    image_filename=\"../images/png_images/adult_income_threshold_corr_matrix.png\",\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Correlation Matrix as a DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.random.seed(42)\n",
+    "df_rand_100 = pd.DataFrame(np.random.rand(100,100))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_corr_thresh_100 = flex_corr_matrix(\n",
+    "    df=df_rand_100,\n",
+    "    cols=df_rand_100.columns.to_list(),\n",
+    "    return_corr=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_corr_thresh_100"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_corr_thresh_32 = flex_corr_matrix(\n",
+    "    df=df_rand_100,\n",
+    "    cols=df_rand_100.columns.to_list(),\n",
+    "    corr_threshold=0.32,\n",
+    "    return_corr=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_corr_thresh_32"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_corr_thresh_100.to_csv(\"../data_output/df_corr_thresh_100.csv\")"
    ]
   },
   {

--- a/src/eda_toolkit/plots.py
+++ b/src/eda_toolkit/plots.py
@@ -2788,8 +2788,11 @@ def flex_corr_matrix(
     significance_method: str = "stars",
     significance_legend_x: float = 0.5,
     filter_significance: Optional[float] = None,
+    corr_threshold: Optional[float] = None,
+    return_corr: bool = False,
+    show_plot: bool = False,
     **kwargs: Dict[str, Any],
-) -> None:
+) -> Optional[pd.DataFrame]:
     """
     Creates a correlation heatmap with extensive customization options, including
     triangular masking, alignment adjustments, title wrapping, dynamic colorbar
@@ -2920,14 +2923,36 @@ def flex_corr_matrix(
         When set, ``show_significance`` is automatically enabled so the
         significance overlay is always visible alongside the filtered matrix.
 
+    corr_threshold : float or None, optional (default=None)
+        If provided, drops any variable whose strongest off-diagonal absolute
+        correlation is below this value, so only features that correlate with
+        at least one other feature at or above the threshold remain in the
+        matrix. This filters *variables*, not individual cells: a surviving
+        variable still displays its weaker correlations (including values
+        below the threshold) against the other survivors. Must be in [0, 1]
+        (e.g. 0.3). Raises if no variable qualifies.
+
+    return_corr : bool, optional (default=False)
+        If True, returns the correlation matrix (as plotted, after any
+        `corr_threshold` / `filter_significance` filtering) as a DataFrame. By
+        default this also suppresses the heatmap; pass `show_plot=True` to
+        render it as well. If False, returns None and always plots.
+
+    show_plot : bool, optional (default=False)
+        Only has an effect when `return_corr=True`. By default, requesting the
+        matrix with `return_corr=True` suppresses the heatmap and returns the
+        data only; set `show_plot=True` to also render the plot. When
+        `return_corr=False` the heatmap always displays and this flag is
+        ignored.
+
     **kwargs : dict, optional
         Additional keyword arguments to pass to `sns.heatmap()`.
 
     Returns:
     --------
-    None
-        This function does not return any value but generates and optionally
-        saves a correlation heatmap.
+    pandas.DataFrame or None
+        The (possibly filtered) correlation matrix if `return_corr=True`,
+        otherwise None.
 
     Raises:
     -------
@@ -2954,6 +2979,9 @@ def flex_corr_matrix(
     ValueError
         If `filter_significance` is not None and is not a positive float.
 
+    ValueError
+        If `corr_threshold` is not None and is not a number in [0, 1].
+
     Notes:
     ------
     - If `triangular=True`, the heatmap will display only the upper triangle
@@ -2969,6 +2997,11 @@ def flex_corr_matrix(
       colorbar for a cleaner plot.
     - When `show_significance=True`, the diagonal always displays "1.00" to
       reflect the perfect self-correlation regardless of significance method.
+    - `corr_threshold` removes whole variables, not cells. A kept variable
+      shows all of its correlations against other kept variables, so some
+      displayed values may be below the threshold.
+    - The returned matrix is the full square matrix; the triangular display
+      mask is not applied to it.
     """
 
     # Validation: Ensure annot is a boolean
@@ -3017,6 +3050,14 @@ def flex_corr_matrix(
         # Auto-enable show_significance so p-values are always computed
         show_significance = True
 
+    # Validate corr_threshold
+    if corr_threshold is not None and (
+        not isinstance(corr_threshold, (int, float)) or not 0 <= corr_threshold <= 1
+    ):
+        raise ValueError(
+            "`corr_threshold` must be a number in [0, 1] (e.g. 0.3) or None."
+        )
+
     # Validate paths are specified if save_plots is True
     if save_plots and not (image_path_png or image_path_svg):
         raise ValueError(
@@ -3046,6 +3087,19 @@ def flex_corr_matrix(
 
     # Eliminate -0.00 display artifact by zeroing out near-zero values
     corr_matrix = corr_matrix.where(corr_matrix.abs() >= 0.005, 0.0)
+
+    # Drop variables whose strongest off-diagonal |r| is below the threshold
+    if corr_threshold is not None:
+        _off = corr_matrix.where(~np.eye(len(corr_matrix), dtype=bool))
+        keep = [c for c in corr_matrix.columns if _off[c].abs().max() >= corr_threshold]
+        if not keep:
+            raise ValueError(
+                f"No variables have an absolute correlation >= {corr_threshold}. "
+                "Lower `corr_threshold`."
+            )
+        df_numeric = df_numeric[keep]
+        corr_matrix = df_numeric.corr(method=corr_method)
+        corr_matrix = corr_matrix.where(corr_matrix.abs() >= 0.005, 0.0)
 
     # Compute pairwise p-value matrix if significance is requested
     if show_significance:
@@ -3134,171 +3188,179 @@ def flex_corr_matrix(
                         annot_data.loc[col_i, col_j] = (
                             f"{corr_matrix.loc[col_i, col_j]:.2f}"
                         )
-            annot_arg = annot_data
-            fmt_arg = ""
+
+        annot_arg = annot_data
+        fmt_arg = ""
     else:
         annot_arg = annot
         fmt_arg = ".2f"
 
-    # Set up the matplotlib figure
-    fig, ax_heatmap = plt.subplots(figsize=figsize)
+    # Plot unless the caller is pulling the dataframe and opted out.
+    # When return_corr is False, plotting always happens regardless of show_plot.
+    if not return_corr or show_plot:
 
-    # Draw the heatmap
-    heatmap = sns.heatmap(
-        corr_matrix,
-        mask=mask,
-        cmap=cmap,
-        annot=annot_arg,
-        fmt=fmt_arg,
-        square=True,
-        linewidths=0.5,
-        cbar=False,
-        vmin=vmin,
-        vmax=vmax,
-        annot_kws={"fontsize": label_fontsize},
-        ax=ax_heatmap,
-        **kwargs,
-    )
+        # Set up the matplotlib figure
+        fig, ax_heatmap = plt.subplots(figsize=figsize)
 
-    # Add the colorbar
-    if show_colorbar:
-        divider = make_axes_locatable(ax_heatmap)
-        cax = divider.append_axes(
-            "right", size=f"{cbar_width_ratio*100}%", pad=cbar_padding
+        # Draw the heatmap
+        heatmap = sns.heatmap(
+            corr_matrix,
+            mask=mask,
+            cmap=cmap,
+            annot=annot_arg,
+            fmt=fmt_arg,
+            square=True,
+            linewidths=0.5,
+            cbar=False,
+            vmin=vmin,
+            vmax=vmax,
+            annot_kws={"fontsize": label_fontsize},
+            ax=ax_heatmap,
+            **kwargs,
         )
 
-        cbar = fig.colorbar(
-            heatmap.collections[0],
-            cax=cax,
-            orientation="vertical",
-        )
+        # Add the colorbar
+        if show_colorbar:
+            divider = make_axes_locatable(ax_heatmap)
+            cax = divider.append_axes(
+                "right", size=f"{cbar_width_ratio*100}%", pad=cbar_padding
+            )
 
-        cbar.ax.tick_params(labelsize=tick_fontsize)
-        cbar.set_label(cbar_label, fontsize=label_fontsize)
+            cbar = fig.colorbar(
+                heatmap.collections[0],
+                cax=cax,
+                orientation="vertical",
+            )
 
-        pos_heatmap = ax_heatmap.get_position()
-        pos_cax = cax.get_position()
-        cax.set_position(
-            [
-                pos_cax.x0,
-                pos_heatmap.y0,
-                pos_cax.width,
-                pos_heatmap.height,
-            ]
-        )
+            cbar.ax.tick_params(labelsize=tick_fontsize)
+            cbar.set_label(cbar_label, fontsize=label_fontsize)
 
-        for spine in cax.spines.values():
-            spine.set_visible(False)
+            pos_heatmap = ax_heatmap.get_position()
+            pos_cax = cax.get_position()
+            cax.set_position(
+                [
+                    pos_cax.x0,
+                    pos_heatmap.y0,
+                    pos_cax.width,
+                    pos_heatmap.height,
+                ]
+            )
 
-    # Set the title if provided
-    if title:
-        ax_heatmap.set_title(
-            "\n".join(textwrap.wrap(title, width=text_wrap)),
-            fontsize=label_fontsize,
-        )
+            for spine in cax.spines.values():
+                spine.set_visible(False)
 
-    # Apply custom labels if label_names is provided
-    if label_names:
-        heatmap.set_xticklabels(
-            [
-                "\n".join(
-                    textwrap.wrap(
-                        label_names.get(label.get_text(), label.get_text()),
-                        width=text_wrap,
+        # Set the title if provided
+        if title:
+            ax_heatmap.set_title(
+                "\n".join(textwrap.wrap(title, width=text_wrap)),
+                fontsize=label_fontsize,
+            )
+
+        # Apply custom labels if label_names is provided
+        if label_names:
+            heatmap.set_xticklabels(
+                [
+                    "\n".join(
+                        textwrap.wrap(
+                            label_names.get(label.get_text(), label.get_text()),
+                            width=text_wrap,
+                        )
                     )
-                )
-                for label in heatmap.get_xticklabels()
-            ],
-            rotation=xlabel_rot,
-            fontsize=tick_fontsize,
-            ha=xlabel_alignment,
-            rotation_mode="anchor",
-        )
-        heatmap.set_yticklabels(
-            [
-                "\n".join(
-                    textwrap.wrap(
-                        label_names.get(label.get_text(), label.get_text()),
-                        width=text_wrap,
+                    for label in heatmap.get_xticklabels()
+                ],
+                rotation=xlabel_rot,
+                fontsize=tick_fontsize,
+                ha=xlabel_alignment,
+                rotation_mode="anchor",
+            )
+            heatmap.set_yticklabels(
+                [
+                    "\n".join(
+                        textwrap.wrap(
+                            label_names.get(label.get_text(), label.get_text()),
+                            width=text_wrap,
+                        )
                     )
-                )
-                for label in heatmap.get_yticklabels()
-            ],
-            rotation=ylabel_rot,
-            fontsize=tick_fontsize,
-            va=ylabel_alignment,
-        )
-    else:
-        heatmap.set_xticklabels(
-            [
-                "\n".join(textwrap.wrap(label.get_text(), width=text_wrap))
-                for label in heatmap.get_xticklabels()
-            ],
-            rotation=xlabel_rot,
-            ha=xlabel_alignment,
-            fontsize=tick_fontsize,
-            rotation_mode="anchor",
-        )
-        heatmap.set_yticklabels(
-            [
-                "\n".join(textwrap.wrap(label.get_text(), width=text_wrap))
-                for label in heatmap.get_yticklabels()
-            ],
-            rotation=ylabel_rot,
-            va=ylabel_alignment,
-            fontsize=tick_fontsize,
-        )
+                    for label in heatmap.get_yticklabels()
+                ],
+                rotation=ylabel_rot,
+                fontsize=tick_fontsize,
+                va=ylabel_alignment,
+            )
+        else:
+            heatmap.set_xticklabels(
+                [
+                    "\n".join(textwrap.wrap(label.get_text(), width=text_wrap))
+                    for label in heatmap.get_xticklabels()
+                ],
+                rotation=xlabel_rot,
+                ha=xlabel_alignment,
+                fontsize=tick_fontsize,
+                rotation_mode="anchor",
+            )
+            heatmap.set_yticklabels(
+                [
+                    "\n".join(textwrap.wrap(label.get_text(), width=text_wrap))
+                    for label in heatmap.get_yticklabels()
+                ],
+                rotation=ylabel_rot,
+                va=ylabel_alignment,
+                fontsize=tick_fontsize,
+            )
 
-    # Adjust layout to prevent overlap
-    plt.subplots_adjust(
-        left=0.1,
-        right=0.9,
-        top=0.9,
-        bottom=0.1,
-        wspace=cbar_padding,
-    )
-
-    # Add significance legend note if stars mode is active
-    if show_significance and significance_method == "stars":
-        fig.canvas.draw()
-        renderer = fig.canvas.get_renderer()
-        tight_bbox = ax_heatmap.get_tightbbox(renderer)
-        fig_height = fig.get_size_inches()[1] * fig.dpi
-        legend_y = (tight_bbox.y0 / fig_height) - 0.05
-
-        fig.text(
-            significance_legend_x,
-            legend_y,
-            "* p < 0.05   ** p < 0.01   *** p < 0.001",
-            ha="center",
-            fontsize=tick_fontsize,
-            style="italic",
-            transform=fig.transFigure,
+        # Adjust layout to prevent overlap
+        plt.subplots_adjust(
+            left=0.1,
+            right=0.9,
+            top=0.9,
+            bottom=0.1,
+            wspace=cbar_padding,
         )
 
-    # Save via image_filename / _save_figure (preferred path)
-    if image_filename is not None:
-        _save_figure(
-            fig=fig,
-            image_path_png=image_path_png,
-            image_path_svg=image_path_svg,
-            filename=image_filename,
-            image_filename=image_filename,
-        )
+        # Add significance legend note if stars mode is active
+        if show_significance and significance_method == "stars":
+            fig.canvas.draw()
+            renderer = fig.canvas.get_renderer()
+            tight_bbox = ax_heatmap.get_tightbbox(renderer)
+            fig_height = fig.get_size_inches()[1] * fig.dpi
+            legend_y = (tight_bbox.y0 / fig_height) - 0.05
 
-    # Legacy save_plots path — derives filename from title
-    elif save_plots:
-        filename_title = title or "Correlation Matrix"
-        safe_title = filename_title.replace(" ", "_").replace(":", "").lower()
-        _save_figure(
-            fig=fig,
-            image_path_png=image_path_png,
-            image_path_svg=image_path_svg,
-            filename=safe_title,
-            image_filename=image_filename,
-        )
+            fig.text(
+                significance_legend_x,
+                legend_y,
+                "* p < 0.05   ** p < 0.01   *** p < 0.001",
+                ha="center",
+                fontsize=tick_fontsize,
+                style="italic",
+                transform=fig.transFigure,
+            )
 
-    plt.show()
+        # Save via image_filename / _save_figure (preferred path)
+        if image_filename is not None:
+            _save_figure(
+                fig=fig,
+                image_path_png=image_path_png,
+                image_path_svg=image_path_svg,
+                filename=image_filename,
+                image_filename=image_filename,
+            )
+
+        # Legacy save_plots path — derives filename from title
+        elif save_plots:
+            filename_title = title or "Correlation Matrix"
+            safe_title = filename_title.replace(" ", "_").replace(":", "").lower()
+            _save_figure(
+                fig=fig,
+                image_path_png=image_path_png,
+                image_path_svg=image_path_svg,
+                filename=safe_title,
+                image_filename=image_filename,
+            )
+
+        plt.show()
+
+    if return_corr:
+        return corr_matrix
 
 
 ################################################################################

--- a/unittests/test_plots.py
+++ b/unittests/test_plots.py
@@ -1722,8 +1722,7 @@ def test_individual_plot_with_best_fit_and_limits(tmp_path):
 
 def test_grouped_distributions_non_binary_raises(binary_df):
     df = binary_df.copy()
-    df["group"] = [0, 1, 2] * (len(df) // 3)
-
+    df["group"] = np.tile([0, 1, 2], len(df))[: len(df)]
     with pytest.raises(ValueError, match="must be binary"):
         grouped_distributions(
             df=df,
@@ -1732,7 +1731,7 @@ def test_grouped_distributions_non_binary_raises(binary_df):
         )
 
 
-def test_grouped_distributions_non_binary_raises(binary_df):
+def test_grouped_distributions_non_binary_raises_tile(binary_df):
     df = binary_df.copy()
     df["group"] = np.tile([0, 1, 2], len(df))[: len(df)]
     with pytest.raises(ValueError, match="must be binary"):
@@ -2064,4 +2063,104 @@ def test_scatter_full_path_fanout(sample_scatter_dataframe, tmp_path):
     files = os.listdir(tmp_path)
     assert any(f.endswith(".png") for f in files)
     assert not any(".png_" in f for f in files)
+    plt.close("all")
+
+
+# ------------------------------------------------------------------
+# corr_threshold (variable-drop)
+# ------------------------------------------------------------------
+
+
+def test_flex_corr_matrix_corr_threshold_drops_uncorrelated(
+    sample_corr_dataframe_large,
+):
+    """corr_threshold drops variables whose strongest |r| is below it.
+
+    In the fixture A/B/D are strongly correlated and C is noise, so a
+    threshold of 0.5 should drop C and keep A, B, D.
+    """
+    result = flex_corr_matrix(
+        sample_corr_dataframe_large,
+        corr_threshold=0.5,
+        return_corr=True,
+    )
+    assert "C" not in result.columns
+    assert set(result.columns) == {"A", "B", "D"}
+
+
+def test_flex_corr_matrix_corr_threshold_no_survivors_raises(
+    sample_corr_dataframe_large,
+):
+    """A threshold no pair can meet raises rather than drawing an empty plot."""
+    with pytest.raises(ValueError, match="No variables have an absolute correlation"):
+        flex_corr_matrix(sample_corr_dataframe_large, corr_threshold=0.999)
+
+
+def test_flex_corr_matrix_corr_threshold_invalid(sample_corr_dataframe):
+    with pytest.raises(ValueError, match="`corr_threshold` must be"):
+        flex_corr_matrix(sample_corr_dataframe, corr_threshold=1.5)
+
+
+# ------------------------------------------------------------------
+# return_corr
+# ------------------------------------------------------------------
+
+
+def test_flex_corr_matrix_return_corr_true(sample_corr_dataframe):
+    """return_corr=True returns the plotted matrix as a square DataFrame."""
+    result = flex_corr_matrix(sample_corr_dataframe, return_corr=True)
+    assert isinstance(result, pd.DataFrame)
+    assert result.shape[0] == result.shape[1]
+    # full square, not triangular-masked
+    assert result.notna().all().all()
+
+
+def test_flex_corr_matrix_return_corr_false_returns_none(sample_corr_dataframe):
+    """Default return_corr=False preserves the old None return."""
+    result = flex_corr_matrix(sample_corr_dataframe, return_corr=False)
+    assert result is None
+
+
+def test_flex_corr_matrix_return_corr_reflects_threshold(
+    sample_corr_dataframe_large,
+):
+    """The returned matrix reflects corr_threshold filtering."""
+    result = flex_corr_matrix(
+        sample_corr_dataframe_large,
+        corr_threshold=0.5,
+        return_corr=True,
+    )
+    assert "C" not in result.columns
+
+
+# ------------------------------------------------------------------
+# show_plot gate (only active with return_corr=True)
+# ------------------------------------------------------------------
+
+
+def test_flex_corr_matrix_return_corr_suppresses_plot(sample_corr_dataframe):
+    """return_corr=True with default show_plot=False returns data and draws no figure."""
+    plt.close("all")
+    result = flex_corr_matrix(sample_corr_dataframe, return_corr=True)
+    assert isinstance(result, pd.DataFrame)
+    assert (
+        len(plt.get_fignums()) == 0
+    ), "No figure should be drawn when show_plot=False."
+
+
+def test_flex_corr_matrix_return_corr_with_show_plot_draws(sample_corr_dataframe):
+    """return_corr=True with show_plot=True returns data AND draws the figure."""
+    plt.close("all")
+    result = flex_corr_matrix(sample_corr_dataframe, return_corr=True, show_plot=True)
+    assert isinstance(result, pd.DataFrame)
+    assert len(plt.get_fignums()) > 0, "A figure should be drawn when show_plot=True."
+    plt.close("all")
+
+
+def test_flex_corr_matrix_show_plot_ignored_without_return_corr(sample_corr_dataframe):
+    """show_plot has no effect when return_corr=False: still plots, still returns None."""
+    plt.close("all")
+    result = flex_corr_matrix(sample_corr_dataframe, show_plot=False)
+    assert result is None
+    assert len(plt.get_fignums()) > 0, "Plot should still draw when return_corr=False."
     plt.close("all")


### PR DESCRIPTION
# Add `corr_threshold`, `return_corr`, and `show_plot` to `flex_corr_matrix`

## Summary

Three additive options for `flex_corr_matrix`: a magnitude-based variable filter (`corr_threshold`), returning the plotted matrix as a DataFrame (`return_corr`), and suppressing the figure when only the data is wanted (`show_plot`). All default to no-op values, so existing calls plot and return `None` exactly as before. Nothing was removed or renamed.

## `corr_threshold`

Filters by correlation magnitude, complementing the p-value filter `filter_significance`. Drops any variable whose strongest off-diagonal `|r|` is below the threshold, so only features correlated with something at or above it remain. This shrinks the matrix (no orphan rows or blank cells); if nothing qualifies it raises rather than drawing an empty plot.

It filters variables, not cells: a surviving variable still shows its weaker correlations against other survivors. The drop runs before the significance block so p-values and the triangular mask stay aligned with the shrunk matrix. Requires a number in `[0, 1]` or `None`.

## `return_corr`

When `True`, returns the plotted matrix (after any filtering) as a DataFrame; return annotation changed `-> None` to `-> Optional[pd.DataFrame]`. Default `False` returns `None`. The returned matrix is the full square; the triangular mask is display-only and not applied to it.

## `show_plot`

Only active when `return_corr=True`. By default `return_corr=True` suppresses the figure and returns data only; `show_plot=True` renders it too. When `return_corr=False` the plot always shows and this flag is ignored.

- `return_corr=False` (default): plots, returns `None` (unchanged).
- `return_corr=True`, `show_plot=False` (default): no plot, returns the DataFrame.
- `return_corr=True`, `show_plot=True`: plots and returns the DataFrame.

## Testing

New tests cover the `corr_threshold` variable-drop and raise-on-empty, invalid-threshold validation, the `return_corr` True/False contract, and `show_plot` suppress/draw/ignored-without-return. Existing tests are unaffected since all three default to no-op.

```text
__________ coverage: platform linux, python 3.12.7-final-0 ____________

Name                                     Stmts   Miss  Cover
------------------------------------------------------------
src/eda_toolkit/__init__.py                 19      2    89%
src/eda_toolkit/_data_manager_utils.py      28      0   100%
src/eda_toolkit/_plot_utils.py             161     23    86%
src/eda_toolkit/art.py                      54      3    94%
src/eda_toolkit/data_manager.py            846     84    90%
src/eda_toolkit/plots.py                  1266    237    81%
------------------------------------------------------------
TOTAL                                     2374    349    85%
```